### PR TITLE
Adding prints to compile log - Version of WPS, if large-file-support, system info, and compiler/version

### DIFF
--- a/compile
+++ b/compile
@@ -109,6 +109,30 @@ else
         exit(1)
 endif
 
+# Print out WPS version, whether built with large-file-support, system info, and compiler/version
+echo "============================================================================================== "
+  echo " "
+  cat version_decl | grep CHARACTER | cut -c 44-53
+  echo " "
+  env | grep LARGE
+  echo " "
+  uname -a
+  echo " "
+  set comp = ( `grep "^SFC" configure.wps | cut -d"=" -f2-` )
+  if      ( "$comp[1]" == "gfortran" ) then
+    gfortran --version
+  else if ( "$comp[1]" == "pgf90" ) then
+    pgf90 --version
+  else if ( "$comp[1]" == "ifort" ) then
+    ifort -V
+  else
+    echo "Not sure how to figure out the version of this compiler: $comp[1]"
+  endif
+  echo " "
+  echo "============================================================================================== "
+  echo " "
+
+
 echo " "
 if ( ${#argv} == 0 ) then
 	echo "**** Compiling WPS and all utilities ****"

--- a/version_decl
+++ b/version_decl
@@ -1,0 +1,5 @@
+  ! This file declares the version for this build of WPS
+  ! This is used by the compile script for the purpose of
+  ! printing the version at the top of the compile log 
+
+  CHARACTER (LEN=10) :: release_version = 'V3.8.1    '


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: compile, log, version_decl, WPS, version, large_file_support, compiler

SOURCE: internal

DESCRIPTION OF CHANGES: Similar to the WRFV3 code, a small section was added in the compile script to print out the version of WPS that is being compiled, whether large-file-support is set, the system information (uname -a), and the compiler (and version of that compiler) that is being used.

LIST OF MODIFIED FILES: 
M                compile
A                 version_decl

TESTS CONDUCTED: Tested a few different compilations to verify that the correct information is printed to the compile log.
