### PR TITLE
Adding Version/Compiler/System Prints to Compile Log

### DIFF
--- a/compile
+++ b/compile
@@ -109,6 +109,28 @@ else
         exit(1)
 endif
 
+# Print out WPS version, system info, and compiler/version
+echo "============================================================================================== "
+  echo " "
+  echo Version 3.9 
+  echo " "
+  uname -a
+  echo " "
+  set comp = ( `grep "^SFC" configure.wps | cut -d"=" -f2-` )
+  if      ( "$comp[1]" == "gfortran" ) then
+    gfortran --version
+  else if ( "$comp[1]" == "pgf90" ) then
+    pgf90 --version
+  else if ( "$comp[1]" == "ifort" ) then
+    ifort -V
+  else
+    echo "Not sure how to figure out the version of this compiler: $comp[1]"
+  endif
+  echo " "
+  echo "============================================================================================== "
+  echo " "
+
+
 echo " "
 if ( ${#argv} == 0 ) then
 	echo "**** Compiling WPS and all utilities ****"


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: compile, compile log, version, system info, compile info

SOURCE: internal

DESCRIPTION OF CHANGES: Added a few lines of code to the 'compile' file in order to print out the version of the code.  This is currently hard-wired as Version 3.9.  We will either need to come up with a more elegant method to have this automatically update with each version, or simply remember to change it with each new release.  There will also be print-outs stating the compiler and system information.

LIST OF MODIFIED FILES: 
M     compile

TESTS CONDUCTED: Tested whether prints appear in compile log.  They do.
