### PR TITLE
Correct 'flag_in_output' values in METGRID.TBL.ARW for QNC and QNR

### DIFF
--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -679,13 +679,13 @@ name=QNC
         interp_option=four_pt+average_4pt
         fill_missing=0.
         fill_lev=200100:const(0.)
-        flag_in_output=FLAG_QNI
+        flag_in_output=FLAG_QNC
 ========================================
 name=QNR
         interp_option=four_pt+average_4pt
         fill_missing=0.
         fill_lev=200100:const(0.)
-        flag_in_output=FLAG_QNI
+        flag_in_output=FLAG_QNR
 ========================================
 name=VPTMP
         interp_option=sixteen_pt+four_pt+average_4pt


### PR DESCRIPTION
The entries for both QNC and QNR in the METGRID.TBL.ARW previously specified
a 'flag_in_output' value of FLAG_QNI. This commit corrects these flag values
to FLAG_QNC and FLAG_QNR, respectively.