### PR TITLE
Fix issue with complex packing in newer NCEP NAM files

### DIFF
--- a/ungrib/src/ngl/g2/comunpack.f
+++ b/ungrib/src/ngl/g2/comunpack.f
@@ -16,6 +16,7 @@
 ! 2004-12-29  Gilbert  -  Added test ( provided by Arthur Taylor/MDL )
 !                         to verify that group widths and lengths are
 !                         consistent with section length.
+! 2016-02-26              update unpacking for template 5.3
 !
 ! USAGE:    CALL comunpack(cpack,len,lensec,idrsnum,idrstmpl,ndpts,fld,ier)
 !   INPUT ARGUMENT LIST:
@@ -109,17 +110,11 @@
 !
       if (idrsnum.eq.3) then
          if (nbitsd.ne.0) then
-              call gbyte(cpack,isign,iofst,1)
-              iofst=iofst+1
-              call gbyte(cpack,ival1,iofst,nbitsd-1)
-              iofst=iofst+nbitsd-1
-              if (isign.eq.1) ival1=-ival1
+              call gbyte(cpack,ival1,iofst,nbitsd)
+              iofst=iofst+nbitsd
               if (idrstmpl(17).eq.2) then
-                 call gbyte(cpack,isign,iofst,1)
-                 iofst=iofst+1
-                 call gbyte(cpack,ival2,iofst,nbitsd-1)
-                 iofst=iofst+nbitsd-1
-                 if (isign.eq.1) ival2=-ival2
+                 call gbyte(cpack,ival2,iofst,nbitsd)
+                 iofst=iofst+nbitsd
               endif
               call gbyte(cpack,isign,iofst,1)
               iofst=iofst+1
@@ -325,12 +320,6 @@
       endif
 
       if ( allocated(ifld) ) deallocate(ifld)
-
-      !open(10,form='unformatted',recl=24180,access='direct') 
-      !read(10,rec=1) (fldo(k),k=1,6045)
-      !do i =1,6045
-      !  print *,i,fldo(i),fld(i),fldo(i)-fld(i)
-      !enddo
 
       return
       end


### PR DESCRIPTION
The packaging of NCEP NAM Grib2 files was changed the week of 20 March 2017, and
the WPS system had troubles reading in the height field correctly. This merge includes
a bug fix from NCEP for their g2 library to properly decode grib2 files using complex packing.
Prior to 20 March 2017 complex packing was not used by model providers. The NAM was
the first NCEP model to use this packing.

Note: This same fix was made available on the WPS v3.8.1 "known problems" page.
