### PR TITLE
Update list of OBJS in util/src/Makefile so int2nc.o is removed upon cleaning

### DIFF
--- a/util/src/Makefile
+++ b/util/src/Makefile
@@ -1,7 +1,7 @@
 include ../../configure.wps
 
 OBJS	=	plotgrids.o avg_tsfc.o calc_ecmwf_p.o elev_angle.o plotfmt.o rd_intermediate.o \
-		mod_levs.o height_ukmo.o \
+		int2nc.o mod_levs.o height_ukmo.o \
 		cio.o gridinfo_module.o misc_definitions_module.o module_debug.o module_stringutil.o \
 		read_met_module.o write_met_module.o module_date_pack.o met_data_module.o constants_module.o
 


### PR DESCRIPTION
Previously, when running './clean', the int2nc.o file in util/src was not
removed; this commit adds int2nc.o to the definition of OBJS, which contains
all object files removed when making the 'clean' target.