### PR TITLE
Update util/src/Makefile so that module_map_utils.o is removed upon cleaning

### DIFF
--- a/util/src/Makefile
+++ b/util/src/Makefile
@@ -3,7 +3,8 @@ include ../../configure.wps
 OBJS	=	plotgrids.o avg_tsfc.o calc_ecmwf_p.o elev_angle.o plotfmt.o rd_intermediate.o \
 		mod_levs.o height_ukmo.o \
 		cio.o gridinfo_module.o misc_definitions_module.o module_debug.o module_stringutil.o \
-		read_met_module.o write_met_module.o module_date_pack.o met_data_module.o constants_module.o
+		read_met_module.o write_met_module.o module_date_pack.o met_data_module.o constants_module.o \
+		module_map_utils.o
 
 all:
 		clear ;


### PR DESCRIPTION
Previously, when running './clean', the module_map_utils.o file in util/src
was not removed; this commit adds module_map_utils.o to the definition of OBJS,
which lists all object files to be removed when making the 'clean' target.

Note that module_map_utils.o is only created when explicitly building
the plotgrids utility.