### PR TITLE
Update arch/preamble so default ncarg_libs are valid for ncar graphics V5.2 (2009) and newer.

### DIFF
--- a/arch/preamble
+++ b/arch/preamble
@@ -16,7 +16,8 @@
 SHELL           	=       /bin/sh
 
 NCARG_LIBS		=	-L$(NCARG_ROOT)/lib -lncarg -lncarg_gks -lncarg_c \
-				-L/usr/X11R6/lib -lX11
+				-lX11 -lXext -lpng -lz -lcairo -lfontconfig -lpixman-1 \
+				-lfreetype -lexpat -lpthread -lbz2 -lXrender -lgfortran -lgcc
 
 NCARG_LIBS2		=	# May be overridden by architecture specific value below
 


### PR DESCRIPTION
The default libs in preamble have been out-of-date for a while. They are only used for plotfmt and plotgrids. 