### PR TITLE
Fix a logic error in the clean script

### DIFF
--- a/clean
+++ b/clean
@@ -62,7 +62,7 @@ if ( "$1" == '-a' ) then
 			/bin/rm -f ${dir}.exe
 		endif
 	end
-	if ( -e configure.wps ) then
+	if ( ( -e configure.wps ) && ( $TOUCH != TOUCH ) ) then
 		/bin/cp -p configure.wps configure.wps.backup
 		/bin/rm -f configure.wps
 	endif


### PR DESCRIPTION
If configure.wps does not exist, clean will create one using touch. Later it will overwrite configure.wps.backup with the empty file. This mod will prevent that.