### PR TITLE
Change the maximum GFS soil moisture value from missing to .468.

### DIFF
--- a/ungrib/src/rrpr.F
+++ b/ungrib/src/rrpr.F
@@ -1261,7 +1261,7 @@ subroutine fix_gfs_miss (ix, jx, plvl)
 	do j = 1, jx
 	do i = 1, ix
 	  if ((f(i,j)) .gt. 0.468) then
-	    f(i,j) = -1.e30
+	    f(i,j) = 0.468
 	  endif
 	enddo
 	enddo


### PR DESCRIPTION
For permanent land ice points the GFS soil moisture can be a value greater then the maximum
of .468 and NCEP recommends setting that to missing. However, a missing value causes
metgrid to run very slowly. Giving the soil moisture a value allows metgrid to run
normally while the soil moisture at this land ice point is not used by WRF. This is an update to PR #41 and only affects the GFS after the July 2017 changes.