### PR TITLE
Fix compilation errors in G2 library when using PGI compilers

### DIFF
--- a/ungrib/src/ngl/g2/mkieee.f
+++ b/ungrib/src/ngl/g2/mkieee.f
@@ -32,6 +32,11 @@
 
       integer(4) :: ieee 
 
+! Recent versions of the PGI compilers apparently still do not fully support
+! the use of all intrinsics in parameter statements, though this is part of
+! the F2003 standard.
+!      real, parameter :: two23=scale(1.0,23)
+!      real, parameter :: two126=scale(1.0,126)
       real :: two23
       real :: two126
 

--- a/ungrib/src/ngl/g2/rdieee.f
+++ b/ungrib/src/ngl/g2/rdieee.f
@@ -32,6 +32,11 @@
 
       integer(4) :: ieee
 
+! Recent versions of the PGI compilers apparently still do not fully support
+! the use of all intrinsics in parameter statements, though this is part of
+! the F2003 standard.
+!      real, parameter :: two23=scale(1.0,23)
+!      real, parameter :: two126=scale(1.0,126)
       real :: two23
       real :: two126
 


### PR DESCRIPTION
Recent versions of the PGI compilers apparently still don't fully support
the use of all intrinsics in parameter statements, though this is part of
the F2003 standard.

In principle, the changes in this commit could reduce performance, since
the variables 'two23' and 'two126' are no longer parameters, but are set
in each subroutine call to rdieee and mkieee.