### PR TITLE
For MPAS files in metgrid, only process fields with METGRID.TBL entries

### DIFF
--- a/metgrid/src/process_domain_module.F
+++ b/metgrid/src/process_domain_module.F
@@ -1659,6 +1659,9 @@ integer, parameter :: BDR_WIDTH = 3
                if (output_this_field(idx) .and. flag_in_output(idx) /= ' ') then
                   output_flags(idx) = flag_in_output(idx)
                end if
+            else
+               istat = scan_input_free_field(mpas_field)
+               cycle
             end if
     
             istat = scan_input_read_field(mpas_field, frame=1)


### PR DESCRIPTION
Generally, we don't want to interpolate every field that may appear in
an MPAS file to a WRF domain (and if we did, we could just create
an entry in the METGRID.TBL file). This commit adds logic to skip over
fields without an entry.