### PR TITLE
Update WPS version to 3.9.1

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-WRF Pre-Processing System Version 3.9.0.1 (13 July 2017)
+WRF Pre-Processing System Version 3.9.1 (17 August 2017)
 
 http://www2.mmm.ucar.edu/wrf/users/
 

--- a/geogrid/src/process_tile_module.F
+++ b/geogrid/src/process_tile_module.F
@@ -300,7 +300,7 @@ module process_tile_module
       end if
 
       ! Initialize the output module now that we have the corner point lats/lons
-      call output_init(which_domain, 'OUTPUT FROM GEOGRID V3.9.0.1', '0000-00-00_00:00:00', grid_type, dynopt, &
+      call output_init(which_domain, 'OUTPUT FROM GEOGRID V3.9.1', '0000-00-00_00:00:00', grid_type, dynopt, &
                        corner_lats, corner_lons, &
                        start_dom_i,   end_dom_i,   start_dom_j,   end_dom_j, &
                        start_patch_i, end_patch_i, start_patch_j, end_patch_j, &

--- a/metgrid/src/input_module.F
+++ b/metgrid/src/input_module.F
@@ -427,7 +427,9 @@ module input_module
 #endif
      
          call ext_get_dom_ti_char          ('TITLE', title)
-         if (index(title,'GEOGRID V3.9.0.1') /= 0) then
+         if (index(title,'GEOGRID V3.9.1') /= 0) then
+            wps_version = 3.91
+         else if (index(title,'GEOGRID V3.9.0.1') /= 0) then
             wps_version = 3.901
          else if (index(title,'GEOGRID V3.9') /= 0) then
             wps_version = 3.9

--- a/metgrid/src/process_domain_module.F
+++ b/metgrid/src/process_domain_module.F
@@ -876,7 +876,7 @@ integer, parameter :: BDR_WIDTH = 3
       !   now we simply output every field from the storage module.
       !
     
-      title = 'OUTPUT FROM METGRID V3.9.0.1' 
+      title = 'OUTPUT FROM METGRID V3.9.1' 
    
       ! Initialize the output module for this domain and time
       call mprintf(.true.,LOGFILE,'Initializing output module.')


### PR DESCRIPTION
This commit updates the README file, as well as the version number
that is stored as a global attribute in the geogrid and metgrid output.