### PR TITLE
Fix rotation of input winds: Cassini to earth relative

### DIFF
--- a/metgrid/src/Makefile
+++ b/metgrid/src/Makefile
@@ -66,7 +66,7 @@ queue_module.o: module_debug.o
 
 read_met_module.o: constants_module.o misc_definitions_module.o module_debug.o met_data_module.o
 
-rotate_winds_module.o: bitarray_module.o constants_module.o llxy_module.o misc_definitions_module.o module_debug.o
+rotate_winds_module.o: bitarray_module.o constants_module.o llxy_module.o misc_definitions_module.o module_debug.o module_map_utils.o
 
 storage_module.o: datatype_module.o minheap_module.o misc_definitions_module.o module_debug.o parallel_module.o module_stringutil.o
 

--- a/metgrid/src/rotate_winds_module.F
+++ b/metgrid/src/rotate_winds_module.F
@@ -161,7 +161,6 @@ module rotate_winds_module
             ! Rotate U field
             do j=us2,ue2
                do i=us1,ue1
-
                   diff = idir * (xlon_u(i,j) - proj_stack(current_nest_number)%stdlon)
                   if (diff > 180.) then
                      diff = diff - 360.
@@ -172,8 +171,7 @@ module rotate_winds_module
                   ! Calculate the rotation angle, alpha, in radians
                   if (proj_stack(current_nest_number)%code == PROJ_LC) then
                      alpha = diff * proj_stack(current_nest_number)%cone * rad_per_deg * proj_stack(current_nest_number)%hemi 
-                  else if (proj_stack(current_nest_number)%code == PROJ_CASSINI) then
-                     if ( idir == 1 ) then
+                  else if ( (proj_stack(SOURCE_PROJ)%code == PROJ_CASSINI) .and. ( idir == 1 ) ) then
                         call latlon_to_ij ( proj_stack(SOURCE_PROJ) , &
                                             xlat_u(i,j), xlon_u(i,j), x_u, y_u )
                         call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
@@ -187,10 +185,10 @@ module rotate_winds_module
                            diff_lon = diff_lon + 360.
                         end if
                         diff_lat = xlat_u_p1-xlat_u_m1
-                        alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
+                        alpha =-atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
                                                         diff_lat*rad_per_deg    &
                                      )
-                     else if ( idir == -1 ) then
+                  else if ( (proj_stack(current_nest_number)%code == PROJ_CASSINI) .and. ( idir == -1 ) ) then
                         if (j == ue2) then
                            diff = xlon_u(i,j)-xlon_u(i,j-1)
                            if (diff > 180.) then
@@ -222,7 +220,6 @@ module rotate_winds_module
                                                            (xlat_u(i,j+1)-xlat_u(i,j-1))*rad_per_deg    &   
                                         )   
                         end if
-                     endif
                   else
                      alpha = diff * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   end if
@@ -281,8 +278,7 @@ module rotate_winds_module
 
                   if (proj_stack(current_nest_number)%code == PROJ_LC) then
                      alpha = diff * proj_stack(current_nest_number)%cone * rad_per_deg * proj_stack(current_nest_number)%hemi 
-                  else if (proj_stack(current_nest_number)%code == PROJ_CASSINI) then
-                     if ( idir == 1 ) then
+                  else if ( (proj_stack(SOURCE_PROJ)%code == PROJ_CASSINI) .and. ( idir == 1 ) ) then
                         call latlon_to_ij ( proj_stack(SOURCE_PROJ) , &
                                             xlat_v(i,j), xlon_v(i,j), x_v, y_v )
                         call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
@@ -296,10 +292,10 @@ module rotate_winds_module
                            diff_lon = diff_lon + 360.
                         end if
                         diff_lat = xlat_v_p1-xlat_v_m1
-                        alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
+                        alpha =-atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
                                                         diff_lat*rad_per_deg    &
                                      )
-                     else if ( idir == -1 ) then
+                  else if ( (proj_stack(current_nest_number)%code == PROJ_CASSINI) .and. ( idir == -1 ) ) then
                         if (j == ve2) then
                            diff = xlon_v(i,j)-xlon_v(i,j-1)
                            if (diff > 180.) then
@@ -331,7 +327,6 @@ module rotate_winds_module
                                                            (xlat_v(i,j+1)-xlat_v(i,j-1))*rad_per_deg    &
                                         )
                         end if
-                     end if
                   else
                      alpha = diff * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   end if

--- a/metgrid/src/rotate_winds_module.F
+++ b/metgrid/src/rotate_winds_module.F
@@ -3,6 +3,7 @@ module rotate_winds_module
    use bitarray_module
    use constants_module
    use llxy_module
+   use map_utils
    use misc_definitions_module
    use module_debug
 
@@ -98,6 +99,10 @@ module rotate_winds_module
       real :: u_map, v_map, alpha, diff
       real, pointer, dimension(:,:) :: u_new, v_new, u_mult, v_mult
       logical :: do_last_col_u, do_last_row_u, do_last_col_v, do_last_row_v
+      real :: x_u, y_u, x_v, y_v
+      real :: xlat_u_p1 , xlon_u_p1, xlat_v_p1 , xlon_v_p1
+      real :: xlat_u_m1 , xlon_u_m1, xlat_v_m1 , xlon_v_m1
+      real :: diff_lon, diff_lat
 
       ! If the proj_info structure has not been initialized, we don't have
       !   information about the projection and standard longitude.
@@ -168,37 +173,22 @@ module rotate_winds_module
                   if (proj_stack(current_nest_number)%code == PROJ_LC) then
                      alpha = diff * proj_stack(current_nest_number)%cone * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   else if (proj_stack(current_nest_number)%code == PROJ_CASSINI) then
-                     if (j == ue2) then
-                        diff = xlon_u(i,j)-xlon_u(i,j-1)
-                        if (diff > 180.) then
-                           diff = diff - 360.
-                        else if (diff < -180.) then
-                           diff = diff + 360.
-                        end if
-                        alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff*rad_per_deg),   &
-                                                        (xlat_u(i,j)-xlat_u(i,j-1))*rad_per_deg    &
-                                     )
-                     else if (j == us2) then
-                        diff = xlon_u(i,j+1)-xlon_u(i,j)
-                        if (diff > 180.) then
-                           diff = diff - 360.
-                        else if (diff < -180.) then
-                           diff = diff + 360.
-                        end if
-                        alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff*rad_per_deg),   &
-                                                        (xlat_u(i,j+1)-xlat_u(i,j))*rad_per_deg    &
-                                     )
-                     else
-                        diff = xlon_u(i,j+1)-xlon_u(i,j-1)
-                        if (diff > 180.) then
-                           diff = diff - 360.
-                        else if (diff < -180.) then
-                           diff = diff + 360.
-                        end if
-                        alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff*rad_per_deg),   &
-                                                        (xlat_u(i,j+1)-xlat_u(i,j-1))*rad_per_deg    &
-                                     )
+                     call latlon_to_ij ( proj_stack(current_nest_number)%code , &
+                                         xlat_u(i,j), xlon_u(i,j), x_u, y_u )
+                     call ij_to_latlon ( proj_stack(current_nest_number)%code , &
+                                         x_u, y_u + 0.1 , xlat_u_p1 , xlon_u_p1 )
+                     call ij_to_latlon ( proj_stack(current_nest_number)%code , &
+                                         x_u, y_u - 0.1 , xlat_u_m1 , xlon_u_m1 )
+                     diff_lon = xlon_u_p1-xlon_u_m1
+                     if (diff_lon > 180.) then
+                        diff_lon = diff_lon - 360.
+                     else if (diff_lon < -180.) then
+                        diff_lon = diff_lon + 360.
                      end if
+                     diff_lat = xlat_u_p1-xlat_u_m1
+                     alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
+                                                     diff_lat*rad_per_deg    &
+                                  )
                   else
                      alpha = diff * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   end if
@@ -258,37 +248,22 @@ module rotate_winds_module
                   if (proj_stack(current_nest_number)%code == PROJ_LC) then
                      alpha = diff * proj_stack(current_nest_number)%cone * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   else if (proj_stack(current_nest_number)%code == PROJ_CASSINI) then
-                     if (j == ve2) then
-                        diff = xlon_v(i,j)-xlon_v(i,j-1)
-                        if (diff > 180.) then
-                           diff = diff - 360.
-                        else if (diff < -180.) then
-                           diff = diff + 360.
-                        end if
-                        alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff*rad_per_deg),   &
-                                                        (xlat_v(i,j)-xlat_v(i,j-1))*rad_per_deg    &
-                                     )
-                     else if (j == vs2) then
-                        diff = xlon_v(i,j+1)-xlon_v(i,j)
-                        if (diff > 180.) then
-                           diff = diff - 360.
-                        else if (diff < -180.) then
-                           diff = diff + 360.
-                        end if
-                        alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff*rad_per_deg),   &
-                                                        (xlat_v(i,j+1)-xlat_v(i,j))*rad_per_deg    &
-                                     )
-                     else
-                        diff = xlon_v(i,j+1)-xlon_v(i,j-1)
-                        if (diff > 180.) then
-                           diff = diff - 360.
-                        else if (diff < -180.) then
-                           diff = diff + 360.
-                        end if
-                        alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff*rad_per_deg),   &
-                                                        (xlat_v(i,j+1)-xlat_v(i,j-1))*rad_per_deg    &
-                                     )
+                     call latlon_to_ij ( proj_stack(current_nest_number)%code , &
+                                         xlat_v(i,j), xlon_v(i,j), x_v, y_v )
+                     call ij_to_latlon ( proj_stack(current_nest_number)%code , &
+                                         x_v, y_v + 0.1 , xlat_v_p1 , xlon_v_p1 )
+                     call ij_to_latlon ( proj_stack(current_nest_number)%code , &
+                                         x_v, y_v - 0.1 , xlat_v_m1 , xlon_v_m1 )
+                     diff_lon = xlon_v_p1-xlon_v_m1
+                     if (diff_lon > 180.) then
+                        diff_lon = diff_lon - 360.
+                     else if (diff_lon < -180.) then
+                        diff_lon = diff_lon + 360.
                      end if
+                     diff_lat = xlat_v_p1-xlat_v_m1
+                     alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
+                                                     diff_lat*rad_per_deg    &
+                                  )
                   else
                      alpha = diff * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   end if

--- a/metgrid/src/rotate_winds_module.F
+++ b/metgrid/src/rotate_winds_module.F
@@ -173,11 +173,11 @@ module rotate_winds_module
                   if (proj_stack(current_nest_number)%code == PROJ_LC) then
                      alpha = diff * proj_stack(current_nest_number)%cone * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   else if (proj_stack(current_nest_number)%code == PROJ_CASSINI) then
-                     call latlon_to_ij ( proj_stack(current_nest_number)%code , &
+                     call latlon_to_ij ( proj_stack(SOURCE_PROJ) , &
                                          xlat_u(i,j), xlon_u(i,j), x_u, y_u )
-                     call ij_to_latlon ( proj_stack(current_nest_number)%code , &
+                     call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
                                          x_u, y_u + 0.1 , xlat_u_p1 , xlon_u_p1 )
-                     call ij_to_latlon ( proj_stack(current_nest_number)%code , &
+                     call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
                                          x_u, y_u - 0.1 , xlat_u_m1 , xlon_u_m1 )
                      diff_lon = xlon_u_p1-xlon_u_m1
                      if (diff_lon > 180.) then
@@ -248,11 +248,11 @@ module rotate_winds_module
                   if (proj_stack(current_nest_number)%code == PROJ_LC) then
                      alpha = diff * proj_stack(current_nest_number)%cone * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   else if (proj_stack(current_nest_number)%code == PROJ_CASSINI) then
-                     call latlon_to_ij ( proj_stack(current_nest_number)%code , &
+                     call latlon_to_ij ( proj_stack(SOURCE_PROJ) , &
                                          xlat_v(i,j), xlon_v(i,j), x_v, y_v )
-                     call ij_to_latlon ( proj_stack(current_nest_number)%code , &
+                     call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
                                          x_v, y_v + 0.1 , xlat_v_p1 , xlon_v_p1 )
-                     call ij_to_latlon ( proj_stack(current_nest_number)%code , &
+                     call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
                                          x_v, y_v - 0.1 , xlat_v_m1 , xlon_v_m1 )
                      diff_lon = xlon_v_p1-xlon_v_m1
                      if (diff_lon > 180.) then

--- a/metgrid/src/rotate_winds_module.F
+++ b/metgrid/src/rotate_winds_module.F
@@ -173,22 +173,56 @@ module rotate_winds_module
                   if (proj_stack(current_nest_number)%code == PROJ_LC) then
                      alpha = diff * proj_stack(current_nest_number)%cone * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   else if (proj_stack(current_nest_number)%code == PROJ_CASSINI) then
-                     call latlon_to_ij ( proj_stack(SOURCE_PROJ) , &
-                                         xlat_u(i,j), xlon_u(i,j), x_u, y_u )
-                     call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
-                                         x_u, y_u + 0.1 , xlat_u_p1 , xlon_u_p1 )
-                     call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
-                                         x_u, y_u - 0.1 , xlat_u_m1 , xlon_u_m1 )
-                     diff_lon = xlon_u_p1-xlon_u_m1
-                     if (diff_lon > 180.) then
-                        diff_lon = diff_lon - 360.
-                     else if (diff_lon < -180.) then
-                        diff_lon = diff_lon + 360.
-                     end if
-                     diff_lat = xlat_u_p1-xlat_u_m1
-                     alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
-                                                     diff_lat*rad_per_deg    &
-                                  )
+                     if ( idir == 1 ) then
+                        call latlon_to_ij ( proj_stack(SOURCE_PROJ) , &
+                                            xlat_u(i,j), xlon_u(i,j), x_u, y_u )
+                        call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
+                                            x_u, y_u + 0.1 , xlat_u_p1 , xlon_u_p1 )
+                        call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
+                                            x_u, y_u - 0.1 , xlat_u_m1 , xlon_u_m1 )
+                        diff_lon = xlon_u_p1-xlon_u_m1
+                        if (diff_lon > 180.) then
+                           diff_lon = diff_lon - 360.
+                        else if (diff_lon < -180.) then
+                           diff_lon = diff_lon + 360.
+                        end if
+                        diff_lat = xlat_u_p1-xlat_u_m1
+                        alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
+                                                        diff_lat*rad_per_deg    &
+                                     )
+                     else if ( idir == -1 ) then
+                        if (j == ue2) then
+                           diff = xlon_u(i,j)-xlon_u(i,j-1)
+                           if (diff > 180.) then
+                              diff = diff - 360.
+                           else if (diff < -180.) then
+                              diff = diff + 360.
+                           end if
+                           alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff*rad_per_deg),   &   
+                                                           (xlat_u(i,j)-xlat_u(i,j-1))*rad_per_deg    &   
+                                        )   
+                        else if (j == us2) then
+                           diff = xlon_u(i,j+1)-xlon_u(i,j)
+                           if (diff > 180.) then
+                              diff = diff - 360.
+                           else if (diff < -180.) then
+                              diff = diff + 360.
+                           end if
+                           alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff*rad_per_deg),   &   
+                                                           (xlat_u(i,j+1)-xlat_u(i,j))*rad_per_deg    &   
+                                        )   
+                        else
+                           diff = xlon_u(i,j+1)-xlon_u(i,j-1)
+                           if (diff > 180.) then
+                              diff = diff - 360.
+                           else if (diff < -180.) then
+                              diff = diff + 360.
+                           end if
+                           alpha = atan2(   (-cos(xlat_u(i,j)*rad_per_deg) * diff*rad_per_deg),   &   
+                                                           (xlat_u(i,j+1)-xlat_u(i,j-1))*rad_per_deg    &   
+                                        )   
+                        end if
+                     endif
                   else
                      alpha = diff * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   end if
@@ -248,22 +282,56 @@ module rotate_winds_module
                   if (proj_stack(current_nest_number)%code == PROJ_LC) then
                      alpha = diff * proj_stack(current_nest_number)%cone * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   else if (proj_stack(current_nest_number)%code == PROJ_CASSINI) then
-                     call latlon_to_ij ( proj_stack(SOURCE_PROJ) , &
-                                         xlat_v(i,j), xlon_v(i,j), x_v, y_v )
-                     call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
-                                         x_v, y_v + 0.1 , xlat_v_p1 , xlon_v_p1 )
-                     call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
-                                         x_v, y_v - 0.1 , xlat_v_m1 , xlon_v_m1 )
-                     diff_lon = xlon_v_p1-xlon_v_m1
-                     if (diff_lon > 180.) then
-                        diff_lon = diff_lon - 360.
-                     else if (diff_lon < -180.) then
-                        diff_lon = diff_lon + 360.
+                     if ( idir == 1 ) then
+                        call latlon_to_ij ( proj_stack(SOURCE_PROJ) , &
+                                            xlat_v(i,j), xlon_v(i,j), x_v, y_v )
+                        call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
+                                            x_v, y_v + 0.1 , xlat_v_p1 , xlon_v_p1 )
+                        call ij_to_latlon ( proj_stack(SOURCE_PROJ) , &
+                                            x_v, y_v - 0.1 , xlat_v_m1 , xlon_v_m1 )
+                        diff_lon = xlon_v_p1-xlon_v_m1
+                        if (diff_lon > 180.) then
+                           diff_lon = diff_lon - 360.
+                        else if (diff_lon < -180.) then
+                           diff_lon = diff_lon + 360.
+                        end if
+                        diff_lat = xlat_v_p1-xlat_v_m1
+                        alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
+                                                        diff_lat*rad_per_deg    &
+                                     )
+                     else if ( idir == -1 ) then
+                        if (j == ve2) then
+                           diff = xlon_v(i,j)-xlon_v(i,j-1)
+                           if (diff > 180.) then
+                              diff = diff - 360.
+                           else if (diff < -180.) then
+                              diff = diff + 360.
+                           end if
+                           alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff*rad_per_deg),   &
+                                                           (xlat_v(i,j)-xlat_v(i,j-1))*rad_per_deg    &
+                                        )
+                        else if (j == vs2) then
+                           diff = xlon_v(i,j+1)-xlon_v(i,j)
+                           if (diff > 180.) then
+                              diff = diff - 360.
+                           else if (diff < -180.) then
+                              diff = diff + 360.
+                           end if
+                           alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff*rad_per_deg),   &
+                                                           (xlat_v(i,j+1)-xlat_v(i,j))*rad_per_deg    &
+                                        )
+                        else
+                           diff = xlon_v(i,j+1)-xlon_v(i,j-1)
+                           if (diff > 180.) then
+                              diff = diff - 360.
+                           else if (diff < -180.) then
+                              diff = diff + 360.
+                           end if
+                           alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff*rad_per_deg),   &
+                                                           (xlat_v(i,j+1)-xlat_v(i,j-1))*rad_per_deg    &
+                                        )
+                        end if
                      end if
-                     diff_lat = xlat_v_p1-xlat_v_m1
-                     alpha = atan2(   (-cos(xlat_v(i,j)*rad_per_deg) * diff_lon*rad_per_deg),   &
-                                                     diff_lat*rad_per_deg    &
-                                  )
                   else
                      alpha = diff * rad_per_deg * proj_stack(current_nest_number)%hemi 
                   end if


### PR DESCRIPTION
Modify the existing met_to_map routine to use the correct rotation
angle, alpha. Previously, the rotation angle was computed with the lat,lon
for the d(lat)/d(y) and d(lon)/d(y) from the interpolated data on the
WRF domain. The correct lat and lon for these d/dy values is to use the
lat lon from the original input data.

The d(lat)/d(y) and d(lon)/d(y) computations use the existing latlon_to_ij
and the inverse ij_to_latlon in the module_map_utils.F file. This module is
now required to be "used" in rotate_winds_module.F, and the associated
Makefile for metgrid is also modified to include this new dependency.

The changes are only made for the Cassini projection (no other test data
exists to try out the other input projections). However, it looks like the
rotation angle alpha needs to have a -1.0 scale factor. Basically, if alpha
is the angle to rotate to go from Earth relative to a projection, then -alpha
is the required angle to take the winds from the projection (in this case, 
Cassini) back to Earth relative.

Tests conducted: 

1. GFS input vs RAP (rotated lat lon) input, each with 4 geogrid 
projections: Lambert, Polar, Mercator, Regional lat/lon. A global domain
is not possible for the regional RAP input data.
2. The sensitivity of the computation of d(lon)/dy and d(lat(dy) was 
considered (dy = 1 is one grid cell unit in the input data). Using dy = 
0.1 vs 1.0 resulted in rotation differences < 0.1 degrees (possibly this
is small due to the input RAP data being pretty high horizontal resolution).