### PR TITLE
image.inmem_=1 causes a compiler error in ungrib

### DIFF
--- a/ungrib/src/ngl/g2/enc_jpeg2000.c
+++ b/ungrib/src/ngl/g2/enc_jpeg2000.c
@@ -138,7 +138,10 @@ int enc_jpeg2000(unsigned char *cin,g2int *pwidth,g2int *pheight,g2int *pnbits,
     image.clrspc_=JAS_CLRSPC_SGRAY;         /* grayscale Image */
     image.cmprof_=0; 
 #endif
-    image.inmem_=1;
+ /* 
+  * Does not seem to be needed, and throws a compiler error
+  * image.inmem_=1;
+  */
 
     cmpt.tlx_=0;
     cmpt.tly_=0;


### PR DESCRIPTION
The inmem field is not a member of image. Commenting out the assignment 
fixes the compiler error, and there are no differences in the generated 
intermediate files (tested with 2 time periods of RAP and 2 time periods of
GFS 0.25 degree).

```
>cmp GFS:2016-04-08_15 INMEM_COMMENTED_OUT/GFS:2016-04-08_15
>cmp GFS:2016-04-08_16 INMEM_COMMENTED_OUT/GFS:2016-04-08_16
>cmp RAP:2016-04-08_15 INMEM_COMMENTED_OUT/RAP:2016-04-08_15
>cmp RAP:2016-04-08_16 INMEM_COMMENTED_OUT/RAP:2016-04-08_16
```

Without the mod, a user sees build errors. For GNU, the errors are innocuous, but should
not be part of the user experience. For Intel 18.0.1, the ungrib program does not build.
```
>grep Error foo
make[2]: [enc_jpeg2000.o] Error 1 (ignored)
make[2]: [libg2_4.a] Error 1 (ignored)
```

The specific error is:
```
gcc -c  -D_UNDERSCORE -DBYTESWAP -DIO_NETCDF -DBIT32 -DMACOS -DNO_SIGNAL  -I/opt/local/include -DUSE_JPEG2000 -DUSE_PNG -D__64BIT__ enc_jpeg2000.c
enc_jpeg2000.c: In function ‘enc_jpeg2000_’:
enc_jpeg2000.c:145:10: error: ‘jas_image_t {aka struct <anonymous>}’ has no member named ‘inmem_’
   * image.inmem_=1;
          ^
make[2]: [enc_jpeg2000.o] Error 1 (ignored)
```

Notes from Jim Bresch:
1. The enc_jpeg2000 routine is only used to encode data for writing a grib2 file. It is not needed for ungrib, so any change to this routine will have no impact. Any change that allows this file to compile is fine.
2. This change will allow ungrib to compile with recent versions of jasper (1.9.x, 2.0.x) which don't have the inmem attribute.
