### PR TITLE
Bug fix when ungribbing gfsb (supplemental pressure level) files by themselves

### DIFF
--- a/ungrib/src/rrpr.F
+++ b/ungrib/src/rrpr.F
@@ -758,8 +758,10 @@ subroutine rrpr(hstart, ntimes, interval, nlvl, maxlvl, plvl, &
         if (index(map%source,'NCEP GFS') .ne. 0 ) then
           call mprintf(.true.,DEBUG, &
              "RRPR:   Adjusting GFS masked fields ")
-             call get_dims(200100, 'ST000010')
-             call fix_gfs_miss (map%nx, map%ny, 200100.)
+	     if ( is_there(200100, 'ST000010')) then
+               call get_dims(200100, 'ST000010')
+               call fix_gfs_miss (map%nx, map%ny, 200100.)
+	     endif
         endif
 
 ! Add residual soil moisture to SOILM* if initialized from the GSD RUC model or from NCEP RUC


### PR DESCRIPTION
The fix for the July 2017 gfs changes should not be applied to the 
gfs supplemental pressure-level files (gfsb) since they do not
contain masked surface fields. Beginning with WPSV3.9.1, ungrib crashes when
decoding a gfsb file. (including gfsb files produced before July 2017). A work-around would be to cat the gfsb file to the corresponding gfs file. This modified code only calls the subroutine when a gfs file contains a soil temperature field.