### PR TITLE
Modify check for global grid for Gaussian and lat/lon grids in rd_gri…

### DIFF
--- a/ungrib/src/rd_grib1.F
+++ b/ungrib/src/rd_grib1.F
@@ -399,7 +399,7 @@ SUBROUTINE rd_grib1(IUNIT, gribflnm, level, field, hdate,  &
      map%lon1 = ginfo(4)
      !  If this is global data, then the dx and dy are more accurately
      !  computed by the number of points than the 3 digits grib permits.
-     if ( ABS(map%nx * map%dx - 360.) .lt. 1 ) then
+     if ( ABS(map%nx * map%dx - 360.) .lt. 2. ) then         ! Check if it's a global grid
         if ( ABS ( map%dx - (360./real(map%nx)) ) .gt. 0.00001 ) then
            !print *,'old dx = ',ginfo(8)
            map%dx = 360./real(map%nx)
@@ -473,7 +473,7 @@ SUBROUTINE rd_grib1(IUNIT, gribflnm, level, field, hdate,  &
      if (tmp8(5:5) .eq. '0') map%grid_wind = .false.
 !  If this is global data, then the dx and dy are more accurately
 !  computed by the number of points than the 3 digits grib permits.
-     if ( ABS(map%nx * map%dx - 360.) .lt. 1. ) then
+     if ( ABS(map%nx * map%dx - 360.) .lt. 2. ) then         ! Check if it's a global grid
         if ( ABS ( map%dx - (360./real(map%nx)) ) .gt. 0.00001 ) then
          ! print *,'old dx = ',ginfo(8)
            map%dx = 360./real(map%nx)


### PR DESCRIPTION
…b1.F.

The high-resolution EC113.1 output revealed a problem with the testing
for a global grid. We test to see if the number_of_points times delta_lon
is close to 360 degrees and if it's 'close' then we assume it's a global
grid. When delta_lon is inaccurate (since it's only 3 digits), the
closeness can be more than 1 degree. So, increase the limit to 2. This
should not be a problem unless someone creates a non-global grid that
is 358 degrees wide.