### PR TITLE
Remove comments from namelist.wps about changes in default datasets in v3.8

### DIFF
--- a/namelist.wps
+++ b/namelist.wps
@@ -14,21 +14,6 @@
  j_parent_start    =   1,  17,
  e_we              =  74, 112,
  e_sn              =  61,  97,
- !
- !!!!!!!!!!!!!!!!!!!!!!!!!!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!
- ! The default datasets used to produce the HGT_M, GREENFRAC, 
- ! and LU_INDEX/LANDUSEF fields have changed in WPS v3.8. The HGT_M field
- ! is now interpolated from 30-arc-second USGS GMTED2010, the GREENFRAC 
- ! field is interpolated from MODIS FPAR, and the LU_INDEX/LANDUSEF fields 
- ! are interpolated from 21-class MODIS.
- !
- ! To match the output given by the default namelist.wps in WPS v3.7.1, 
- ! the following setting for geog_data_res may be used:
- !
- ! geog_data_res = 'gtopo_10m+usgs_10m+nesdis_greenfrac+10m','gtopo_2m+usgs_2m+nesdis_greenfrac+2m',
- !
- !!!!!!!!!!!!!!!!!!!!!!!!!!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!
- !
  geog_data_res = 'default','default',
  dx = 30000,
  dy = 30000,


### PR DESCRIPTION
WPS v3.8 was released roughly two years ago, so the comments warning users
that the default static datasets were changed from v3.7.1 are probably no
longer needed. Of course, if users are upgrading from v3.7.1 or earlier
they may be taken by surprise, but with an increment in the major version
number, significant changes should probably be expected.