### PR TITLE
Add MODIS sources for ALBEDO12M and SNOALB fields in ARW GEOGRID.TBL variants

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -123,7 +123,9 @@ name=ALBEDO12M
         z_dim_name=month
         masked = water
         fill_missing = 8.
+        interp_option=albedo_modis:four_pt+average_4pt+average_16pt+search
         interp_option=default:four_pt+average_4pt+average_16pt+search
+        rel_path=albedo_modis:albedo_modis/
         rel_path=default:albedo_ncep/
 ===============================
 name=GREENFRAC
@@ -154,9 +156,11 @@ name=LAI12M
 name=SNOALB
         priority=1
         dest_type=continuous
+        interp_option=maxsnowalb_modis:four_pt+average_4pt+average_16pt+search
         interp_option=default:four_pt+average_4pt+average_16pt+search
         masked = water
         fill_missing = 0.
+        rel_path=maxsnowalb_modis:maxsnowalb_modis/
         rel_path=default:maxsnowalb/
 ===============================
 name=SLOPECAT

--- a/geogrid/GEOGRID.TBL.ARW.noahmp
+++ b/geogrid/GEOGRID.TBL.ARW.noahmp
@@ -123,7 +123,9 @@ name=ALBEDO12M
         z_dim_name=month
         masked = water
         fill_missing = 8.
+        interp_option=albedo_modis:four_pt+average_4pt+average_16pt+search
         interp_option=default:four_pt+average_4pt+average_16pt+search
+        rel_path=albedo_modis:albedo_modis/
         rel_path=default:albedo_ncep/
 ===============================
 name=GREENFRAC
@@ -154,9 +156,11 @@ name=LAI12M
 name=SNOALB
         priority=1
         dest_type=continuous
+        interp_option=maxsnowalb_modis:four_pt+average_4pt+average_16pt+search
         interp_option=default:four_pt+average_4pt+average_16pt+search
         masked = water
         fill_missing = 0.
+        rel_path=maxsnowalb_modis:maxsnowalb_modis/
         rel_path=default:maxsnowalb/
 ===============================
 name=SLOPECAT

--- a/geogrid/GEOGRID.TBL.ARW_CHEM
+++ b/geogrid/GEOGRID.TBL.ARW_CHEM
@@ -116,7 +116,9 @@ name=ALBEDO12M
         z_dim_name=month
         masked = water
         fill_missing = 8.
+        interp_option=albedo_modis:four_pt+average_4pt+average_16pt+search
         interp_option=default:four_pt+average_4pt+average_16pt+search
+        rel_path=albedo_modis:albedo_modis/
         rel_path=default:albedo_ncep/
 ===============================
 name=GREENFRAC
@@ -147,9 +149,11 @@ name=LAI12M
 name=SNOALB
         priority=1
         dest_type=continuous
+        interp_option=maxsnowalb_modis:four_pt+average_4pt+average_16pt+search
         interp_option=default:four_pt+average_4pt+average_16pt+search
         masked = water
         fill_missing = 0.
+        rel_path=maxsnowalb_modis:maxsnowalb_modis/
         rel_path=default:maxsnowalb/
 ===============================
 name=SLOPECAT

--- a/geogrid/GEOGRID.TBL.FIRE
+++ b/geogrid/GEOGRID.TBL.FIRE
@@ -297,7 +297,9 @@ name=ALBEDO12M
         z_dim_name=month
         masked = water
         fill_missing = 8.
+        interp_option=albedo_modis:four_pt+average_4pt+average_16pt+search
         interp_option=default:four_pt+average_4pt+average_16pt+search
+        rel_path=albedo_modis:albedo_modis/
         rel_path=default:albedo_ncep/
 ===============================
 name=GREENFRAC
@@ -328,9 +330,11 @@ name=LAI12M
 name=SNOALB
         priority=1
         dest_type=continuous
+        interp_option=maxsnowalb_modis:four_pt+average_4pt+average_16pt+search
         interp_option=default:four_pt+average_4pt+average_16pt+search
         masked = water
         fill_missing = 0.
+        rel_path=maxsnowalb_modis:maxsnowalb_modis/
         rel_path=default:maxsnowalb/
 ===============================
 name=SLOPECAT


### PR DESCRIPTION
The MODIS sources for monthly albedo and maximum snow albedo may be activated
by prefixing the geog_data_res setting, e.g.,

   geog_data_res = 'albedo_modis+maxsnowalb_modis+default'

in the namelist.wps file.