### PR TITLE
Add soilgrids data to GEOGRID.TBL.ARW.noahmp

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW.noahmp
+++ b/geogrid/GEOGRID.TBL.ARW.noahmp
@@ -487,7 +487,7 @@ name=SOILCOMP
         dest_type=continuous
         interp_option=soilgrids:average_gcell(0.0)+average_4pt+average_16pt
         z_dim_name=soilcomp
-#        masked = water
+        masked = water
         fill_missing = 0.
         rel_path=soilgrids:soilgrids/soilcomp/
 ===============================


### PR DESCRIPTION
Add soilgrids data to GEOGRID.TBL.ARW.noahmp for use in the new soil composition option in Noah-MP (see PR #402 from WRF repo). There are several options for using this data:

1. 0-1 meter and 1-2 meter texture classes, same as standard texture data
2. Texture class for each of the four standard Noah-MP soil layers
3. Soil composition (sand, clay fractions) for each of the four layers

Note from GEOGRID.TBL.ARW.noahmp that the data should reside as, e.g.,:

geog_path/soilgrids/soilcomp
geog_path/soilgrids/texture_top
etc.

For now, this is only a Noah-MP dataset, but could be extended to other models. To activate the dataset, users must add `soilgrids+` to `geog_data_path`.