### PR TITLE
Fix occasional NaNs in XLONG_* fields for polar stereographic projection

### DIFF
--- a/geogrid/src/module_map_utils.F
+++ b/geogrid/src/module_map_utils.F
@@ -805,7 +805,7 @@ MODULE map_utils
       ELSE
          gi2 = (proj%rebydx * scale_top)**2.
          lat = deg_per_rad * proj%hemi * ASIN((gi2-r2)/(gi2+r2))
-         arccos = ACOS(xx/SQRT(r2))
+         arccos = ACOS(MIN(MAX(xx/SQRT(r2),-1.0),1.0))
          IF (yy .GT. 0) THEN
             lon = reflon + deg_per_rad * arccos
          ELSE


### PR DESCRIPTION
With some compilers, and with particular choices of projection parameters,
NaNs may appear in the XLONG_* fields produced by geogrid due to rounding
errors in the two terms used in the computation of the longitude.

Specifically, the conversion from (i,j) coordinates to (lat,lon) coordinates
for the polar projection uses the arccosine of the ratio of the x-coordinate
of the point to the radius from the pole of the projection to the point when
computing the longitude. It can sometimes happen that the radius is computed
as slightly less than the x-coordinate, causing the code to call the ACOS
function with an argument that is outside the range [-1,1].

The solution in this commit is to bound the argument to the ACOS function.