### PR TITLE
Fix latitude computation near poles in polar stereographic projections

### DIFF
--- a/geogrid/src/module_map_utils.F
+++ b/geogrid/src/module_map_utils.F
@@ -781,7 +781,7 @@ MODULE map_utils
       REAL                                :: reflon
       REAL                                :: scale_top
       REAL                                :: xx,yy
-      REAL                                :: gi2, r2
+      REAL(KIND=HIGH)                     :: gi2, r2
       REAL                                :: arccos
   
       ! Begin Code


### PR DESCRIPTION
Promote only the two arguments to the arcsin to each be real(kind=high). For "near pole" computations, this PR fixes the problem of lots of grid points having the same +-90 latitude for a polar projection.

Sample case: 
20x20 grid cells, Polar Stereographic, centered at 90N, 200 m grid space

Before mods. Every point that is "red" is exactly 90.0 N.
<img width="1270" alt="screen shot 2018-05-25 at 3 32 33 pm" src="https://user-images.githubusercontent.com/12666234/40567140-594d26bc-6031-11e8-932b-b4850aca187c.png">


After mods. Only a single 90 N value, and the domain is symmetric.
<img width="1268" alt="screen shot 2018-05-25 at 4 10 56 pm" src="https://user-images.githubusercontent.com/12666234/40568524-4d12023a-6038-11e8-9f15-432a8948ffc3.png">

After mods, south pole, also looks good:
<img width="1271" alt="screen shot 2018-05-25 at 4 09 37 pm" src="https://user-images.githubusercontent.com/12666234/40568528-55257aec-6038-11e8-9e82-bf5f0651952f.png">

In an absolute sense, with the 200 m resolution and being 9 grid points from the boundary, we can compute what the latitude should be at the center of each side of the domain.

delta_lat = ( 9 grid cells ) * ( 0.200 km / grid cell ) /  (0.933 map factor km/km ) * ( 1 degree / 111 km ) 
delta_lat = 0.01738 degree
90 N - 0.0162 degree = 89.9826 degree
The reported value in the data set is 89.9826.
This is a difference of about O(1 m).
