### PR TITLE
Remove SLOPECAT field from all GEOGRID.TBL files

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -167,16 +167,6 @@ name=SNOALB
         rel_path=maxsnowalb_ncep:maxsnowalb/
         rel_path=default:maxsnowalb_modis/
 ===============================
-name=SLOPECAT
-        priority=1
-        dominant_only=SLOPECAT
-        dest_type=categorical
-        z_dim_name=slope_cat
-        masked = water
-        fill_missing = 0.
-        interp_option=default:nearest_neighbor+average_16pt+search
-        rel_path=default:islope/
-===============================
 name = CON
         priority = 1
         dest_type = continuous

--- a/geogrid/GEOGRID.TBL.ARW.noahmp
+++ b/geogrid/GEOGRID.TBL.ARW.noahmp
@@ -171,16 +171,6 @@ name=SNOALB
         rel_path=maxsnowalb_ncep:maxsnowalb/
         rel_path=default:maxsnowalb_modis/
 ===============================
-name=SLOPECAT
-        priority=1
-        dominant_only=SLOPECAT
-        dest_type=categorical
-        z_dim_name=slope_cat
-        masked = water
-        fill_missing = 0.
-        interp_option=default:nearest_neighbor+average_16pt+search
-        rel_path=default:islope/
-===============================
 name = CON
         priority = 1
         dest_type = continuous

--- a/geogrid/GEOGRID.TBL.ARW_CHEM
+++ b/geogrid/GEOGRID.TBL.ARW_CHEM
@@ -156,16 +156,6 @@ name=SNOALB
         rel_path=maxsnowalb_modis:maxsnowalb_modis/
         rel_path=default:maxsnowalb/
 ===============================
-name=SLOPECAT
-        priority=1
-        dominant_only=SLOPECAT
-        dest_type=categorical
-        z_dim_name=slope_cat
-        masked = water
-        fill_missing = 0.
-        interp_option=default:nearest_neighbor+average_16pt+search
-        rel_path=default:islope/
-===============================
 name = CON
         priority = 1
         dest_type = continuous

--- a/geogrid/GEOGRID.TBL.FIRE
+++ b/geogrid/GEOGRID.TBL.FIRE
@@ -337,16 +337,6 @@ name=SNOALB
         rel_path=maxsnowalb_modis:maxsnowalb_modis/
         rel_path=default:maxsnowalb/
 ===============================
-name=SLOPECAT
-        priority=1
-        dominant_only=SLOPECAT
-        dest_type=categorical
-        z_dim_name=slope_cat
-        masked = water
-        fill_missing = 0.
-        interp_option=default:nearest_neighbor+average_16pt+search
-        rel_path=default:islope/
-===============================
 name=NFUEL_CAT
         priority=1
 	dest_type=categorical

--- a/geogrid/GEOGRID.TBL.NMM
+++ b/geogrid/GEOGRID.TBL.NMM
@@ -216,13 +216,3 @@ name=SNOALB
         fill_missing = 0.
         rel_path=default:maxsnowalb/
 ===============================
-name=SLOPECAT
-        priority=1
-        dominant_only=SLOPECAT
-        dest_type=categorical
-        z_dim_name=slope_cat
-        masked = water
-        fill_missing = 0.
-        interp_option=default:nearest_neighbor+average_16pt+search
-        rel_path=default:islope/
-===============================


### PR DESCRIPTION
The SLOPECAT field is never used in WRF ARW or WRF NMM.