### PR TITLE
Add FRC_URB2D entry to all ARW GEOGRID.TBL files

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -380,6 +380,15 @@ name=URB_PARAM
         interp_option=default:nearest_neighbor
         rel_path=default:NUDAPT44_1km/
 ===============================
+name=FRC_URB2D
+        priority=1
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        interp_option=default: average_gcell(2.0)+four_pt
+        rel_path=default:urbfrac_nlcd2011/
+        flag_in_output=FLAG_FRC_URB2D
+===============================
 name=IMPERV
         priority=1
         optional=yes

--- a/geogrid/GEOGRID.TBL.ARW.noahmp
+++ b/geogrid/GEOGRID.TBL.ARW.noahmp
@@ -384,6 +384,15 @@ name=URB_PARAM
         interp_option=default:nearest_neighbor
         rel_path=default:NUDAPT44_1km/
 ===============================
+name=FRC_URB2D
+        priority=1
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        interp_option=default: average_gcell(2.0)+four_pt
+        rel_path=default:urbfrac_nlcd2011/
+        flag_in_output=FLAG_FRC_URB2D
+===============================
 name=IMPERV
         priority=1
         optional=yes

--- a/geogrid/GEOGRID.TBL.ARW_CHEM
+++ b/geogrid/GEOGRID.TBL.ARW_CHEM
@@ -394,3 +394,12 @@ name=URB_PARAM
         interp_option=default:nearest_neighbor
         rel_path=default:NUDAPT44_1km/
 ===============================
+name=FRC_URB2D
+        priority=1
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        interp_option=default: average_gcell(2.0)+four_pt
+        rel_path=default:urbfrac_nlcd2011/
+        flag_in_output=FLAG_FRC_URB2D
+===============================

--- a/geogrid/GEOGRID.TBL.FIRE
+++ b/geogrid/GEOGRID.TBL.FIRE
@@ -380,3 +380,12 @@ name=URB_PARAM
         interp_option=default:nearest_neighbor
         rel_path=default:NUDAPT44_1km/
 ===============================
+name=FRC_URB2D
+        priority=1
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        interp_option=default: average_gcell(2.0)+four_pt
+        rel_path=default:urbfrac_nlcd2011/
+        flag_in_output=FLAG_FRC_URB2D
+===============================


### PR DESCRIPTION
The FRC_URB2D field was derived from the NLCD 2011 30-m dataset
using the following urban fractions:

category 22 = 50%, category 23 = 90%, category 24 = 95%