### PR TITLE
Make LAKE_DEPTH and VAR_SSO optional fields in all ARW GEOGRID.TBL files

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -349,6 +349,7 @@ name = OL4
 ===============================
 name = VAR_SSO 
         priority = 1
+        optional=yes
         dest_type = continuous
         fill_missing=0.
         interp_option =   30s:average_gcell(4.0)+four_pt+average_4pt
@@ -364,6 +365,7 @@ name = VAR_SSO
 ===============================
 name = LAKE_DEPTH
         priority=1
+        optional=yes
         dest_type = continuous
         fill_missing = 10.
         masked=land

--- a/geogrid/GEOGRID.TBL.ARW.noahmp
+++ b/geogrid/GEOGRID.TBL.ARW.noahmp
@@ -353,6 +353,7 @@ name = OL4
 ===============================
 name = VAR_SSO 
         priority = 1
+        optional=yes
         dest_type = continuous
         fill_missing=0.
         interp_option =   30s:average_gcell(4.0)+four_pt+average_4pt
@@ -368,6 +369,7 @@ name = VAR_SSO
 ===============================
 name = LAKE_DEPTH
         priority=1
+        optional=yes
         dest_type = continuous
         fill_missing = 10.
         masked=land

--- a/geogrid/GEOGRID.TBL.ARW_CHEM
+++ b/geogrid/GEOGRID.TBL.ARW_CHEM
@@ -363,6 +363,7 @@ name = SANDFRAC
 ===============================
 name = VAR_SSO 
         priority = 1
+        optional=yes
         dest_type = continuous
         fill_missing=0.
         interp_option =   30s:average_gcell(4.0)+four_pt+average_4pt
@@ -378,6 +379,7 @@ name = VAR_SSO
 ===============================
 name = LAKE_DEPTH
         priority=1
+        optional=yes
         dest_type = continuous
         fill_missing = 10.
         masked=land

--- a/geogrid/GEOGRID.TBL.FIRE
+++ b/geogrid/GEOGRID.TBL.FIRE
@@ -349,6 +349,7 @@ name=NFUEL_CAT
 ===============================
 name = VAR_SSO 
         priority = 1
+        optional=yes
         dest_type = continuous
         fill_missing=0.
         interp_option =   30s:average_gcell(4.0)+four_pt+average_4pt
@@ -364,6 +365,7 @@ name = VAR_SSO
 ===============================
 name = LAKE_DEPTH
         priority=1
+        optional=yes
         dest_type = continuous
         fill_missing = 10.
         masked=land


### PR DESCRIPTION
The LAKE_DEPTH field is only needed by a particular model option, as is
the VAR_SSO field. Any ARW simulations that do not use these options do
not need the corresponding fields from geogrid.