### PR TITLE
Add a new namelist variable, pmin, to &ungrib to specify the minimum pressure level to process

### DIFF
--- a/namelist.wps.all_options
+++ b/namelist.wps.all_options
@@ -68,6 +68,8 @@
 &ungrib
  out_format = 'WPS',
  prefix     = 'FILE',
+ ec_rec_len = 26214508,
+ pmin = 100.
 /
 
 &metgrid

--- a/ungrib/src/rd_grib1.F
+++ b/ungrib/src/rd_grib1.F
@@ -22,6 +22,8 @@
 !                 file GRIBFLNM must be opened, and the value of IUARR(IUNIT) !
 !                 becomes the UNIX File descriptor to read from.              !
 !       DEBUG_LEVEL Integer for various amounts of printout.                    !
+!       EC_REC_LEN :  Record length for EC ds113.0 files.                     !
+!       PMIN    : Minimum pressure level (Pa) to process.                     !
 !                                                                             !
 !    Output:                                                                  !
 !       LEVEL    : The pressure-level (Pa) of the field to process.           !
@@ -60,7 +62,7 @@
 !                                                                             !
 !*****************************************************************************!
 SUBROUTINE rd_grib1(IUNIT, gribflnm, level, field, hdate,  &
-     ierr, iuarr, debug_level, ec_rec_len)
+     ierr, iuarr, debug_level, ec_rec_len, pmin)
   use table
   use gridinfo
   use datarray
@@ -91,6 +93,7 @@ SUBROUTINE rd_grib1(IUNIT, gribflnm, level, field, hdate,  &
   integer :: i, lvl2, lvl1
   character(LEN=19) :: hdate
   integer :: igherr
+  real :: pmin
 
 ! Variables for thinned grids:
   logical :: lthinned = .FALSE.
@@ -296,6 +299,7 @@ SUBROUTINE rd_grib1(IUNIT, gribflnm, level, field, hdate,  &
                  level = -999.
                  if (ktype.eq.100) then ! Pressure-level
                     level=lvl1
+		    if ( level .lt. pmin ) field = 'NULL'
                  elseif (ktype.eq.102) then
                     level=201300.
                  elseif ((ktype.eq.116.and.lvl1.le.50.and.lvl2.eq.0) .or. &

--- a/ungrib/src/rd_grib2.F
+++ b/ungrib/src/rd_grib2.F
@@ -18,6 +18,7 @@
 !                 stored.                                                     !
 !       gribflnm     : File name to open, if it is not already open.          !
 !       debug_level  : Integer for various amounts of printout.               !
+!       pmin         : Minimum pressure level (Pa) to process.                !
 !                                                                             !
 !    Output:                                                                  !
 !                                                                             !
@@ -35,7 +36,7 @@
 !*****************************************************************************!
       
       SUBROUTINE rd_grib2(junit, gribflnm, hdate, 
-     &  grib_edition, ireaderr, debug_level)
+     &  grib_edition, ireaderr, debug_level, pmin)
 
       use grib_mod
       use params
@@ -75,6 +76,7 @@
       integer , dimension(maxlvl) :: level_array
       real :: glevel1, glevel2
       logical :: first = .true.
+      real :: pmin
 
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 C  SET ARGUMENTS
@@ -327,6 +329,18 @@ C  SET ARGUMENTS
            else
              map%source = 'unknown model and orig center'
            end if
+           if (icenter.eq.7) then
+             if (iprocess.eq.81 .or. iprocess.eq.82 .or.
+     &           iprocess.eq.96) then
+!  pmin should not be 15 or 40 hPa for gfs files. Use the next highest level.
+               if (pmin .eq. 1500.) then
+                 pmin = 1000.
+               else if (pmin .eq. 4000.) then
+                 pmin = 3000.
+               endif
+             endif
+           endif
+
            call mprintf(.true.,DEBUG,"G2 source is = %s ",
      &                  newline=.true., s1=map%source)
 
@@ -741,6 +755,7 @@ C  SET ARGUMENTS
                  ! Pressure level (range from 1000mb to 0mb)
                  level=gfld%ipdtmpl(12) *
      &                           (10. ** (-1. * gfld%ipdtmpl(11)))
+		 if ( level .lt. pmin ) cycle MATCH_LOOP
               elseif((gfld%ipdtmpl(10).eq.105).or.
      &               (gfld%ipdtmpl(10).eq.118))then
                  ! Hybrid level (range from 1 to N)

--- a/ungrib/src/read_namelist.F
+++ b/ungrib/src/read_namelist.F
@@ -1,6 +1,6 @@
 subroutine read_namelist(hstart, hend, delta_time, ntimes,&
      ordered_by_date, debug_level, out_format, prefix,    &
-     add_lvls, new_plvl_in, interp_type, ec_rec_len)
+     add_lvls, new_plvl_in, interp_type, ec_rec_len, pmin)
 
   use misc_definitions_module
   use module_debug
@@ -16,6 +16,7 @@ subroutine read_namelist(hstart, hend, delta_time, ntimes,&
   real, dimension(:) :: new_plvl_in
   logical :: add_lvls
   integer :: interp_type, ec_rec_len
+  real :: pmin
 
   integer :: ierr
   integer :: idts
@@ -69,7 +70,7 @@ subroutine read_namelist(hstart, hend, delta_time, ntimes,&
 
   namelist /ungrib/ out_format, &
        ordered_by_date, prefix, &
-       add_lvls, new_plvl, interp_type, ec_rec_len
+       add_lvls, new_plvl, interp_type, ec_rec_len, pmin
 
   allocate(new_plvl(size(new_plvl_in)))
 
@@ -98,6 +99,7 @@ subroutine read_namelist(hstart, hend, delta_time, ntimes,&
   new_plvl = -99999.
   interp_type = 0
   ec_rec_len = 0
+  pmin = 100.    ! default is 1 hPa (48 km)
 
 ! Start routine:
 

--- a/ungrib/src/ungrib.F
+++ b/ungrib/src/ungrib.F
@@ -57,7 +57,7 @@ program ungrib
   interface
    subroutine read_namelist(hstart, hend, delta_time, ntimes,&
     ordered_by_date, debug_level, out_format, prefix,    &
-    add_lvls, new_plvl, interp_type, ec_rec_len)
+    add_lvls, new_plvl, interp_type, ec_rec_len, pmin)
   
     use misc_definitions_module
 
@@ -71,6 +71,7 @@ program ungrib
     logical :: add_lvls
     real, dimension(:) :: new_plvl
     integer :: interp_type, ec_rec_len
+    real :: pmin
    end subroutine read_namelist
   end interface 
 
@@ -85,6 +86,7 @@ program ungrib
   integer :: iplvl
   logical :: add_lvls
   integer :: interp_type, ec_rec_len
+  real :: pmin
 
   integer :: nlvl
 
@@ -116,7 +118,7 @@ program ungrib
 
   call read_namelist(hstart, hend, interval, ntimes, &
        ordered_by_date, debug_level, out_format, prefix, &
-       add_lvls, new_plvl, interp_type, ec_rec_len)
+       add_lvls, new_plvl, interp_type, ec_rec_len, pmin)
 
   call mprintf(.true.,INFORM,"Interval value: %i seconds or  %f hours", &
                i1=interval, f1=float(interval)/3600.)
@@ -232,13 +234,13 @@ program ungrib
 		     "flnm = %s",s1=gribflnm)
                  ! Read one record at a time from GRIB1 (and older Editions) 
                  call rd_grib1(nunit1, gribflnm, level, field, &
-                      hdate, ierr, iuarr, debug_level, ec_rec_len)
+                      hdate, ierr, iuarr, debug_level, ec_rec_len, pmin)
               else 
 
                  ! Read one file of records from GRIB2.
                  call mprintf(.true.,DEBUG,"Calling rd_grib2")
                  call rd_grib2(nunit1, gribflnm, hdate, &
-                      grib_version, ierr, debug_level)
+                      grib_version, ierr, debug_level, pmin)
                  FIELD='NULL'
 
               endif


### PR DESCRIPTION


Some new NCEP output adds fields as high as 40 Pa. This is too high for typical
wrf applications. Because users will disagree about what is 'too high', they can
now specify their desired minimum pressure level. Setting pmin works for both
grib1 (EC) and grib2 files. Default is set to 100 Pa (1 mb or about  48 km).
For reference 1000 Pa is about 31 km, 40 Pa is 70 km, and 2000 Pa is 27 km.
It is recommended that pmin be equal to or smaller than p_top_requested in the
wrf namelist. Setting pmin=0. is the same as the current behavior which is to process
every pressure level (level code=100) in the grib file.

Using pmin has the added benefit of reducing wall clock time as well as the size
of the intermediate files since stratospheric levels can now be skipped.

Tested on GFS/FV3 and ERA-I files.