### PR TITLE
Add flags for VAR_SSO, URB_PARAM, IMPERV, CANFRA

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -403,6 +403,7 @@ name = VAR_SSO
         rel_path =        10m:varsso_10m/
         rel_path =        lowres:varsso_10m/
         rel_path =        default:varsso_10m/
+        flag_in_output=FLAG_VAR_SSO
 ===============================
 name = LAKE_DEPTH
         priority=1
@@ -422,6 +423,7 @@ name=URB_PARAM
         z_dim_name=num_urb_params
         interp_option=default:nearest_neighbor
         rel_path=default:NUDAPT44_1km/
+        flag_in_output=FLAG_URB_PARAM
 ===============================
 name=FRC_URB2D
         priority=1
@@ -440,6 +442,7 @@ name=IMPERV
         masked=water
         fill_missing=0.
         rel_path = default:nlcd2011_imp_ll_9s/
+        flag_in_output=FLAG_IMPERV
 ===============================
 name=CANFRA
         priority=1
@@ -449,6 +452,7 @@ name=CANFRA
         masked=water
         fill_missing=0.
         rel_path = default:nlcd2011_can_ll_9s/
+        flag_in_output=FLAG_CANFRA
 ===============================
 name = EROD
         priority = 1

--- a/geogrid/GEOGRID.TBL.ARW.noahmp
+++ b/geogrid/GEOGRID.TBL.ARW.noahmp
@@ -366,6 +366,7 @@ name = VAR_SSO
         rel_path =        5m:varsso_5m/
         rel_path =        10m:varsso_10m/
         rel_path =        default:varsso_10m/
+        flag_in_output=FLAG_VAR_SSO
 ===============================
 name = LAKE_DEPTH
         priority=1
@@ -385,6 +386,7 @@ name=URB_PARAM
         z_dim_name=num_urb_params
         interp_option=default:nearest_neighbor
         rel_path=default:NUDAPT44_1km/
+        flag_in_output=FLAG_URB_PARAM
 ===============================
 name=FRC_URB2D
         priority=1
@@ -403,6 +405,7 @@ name=IMPERV
         masked=water
         fill_missing=0.
         rel_path = default:nlcd2011_imp_ll_9s/
+        flag_in_output=FLAG_IMPERV
 ===============================
 name=CANFRA
         priority=1
@@ -412,6 +415,7 @@ name=CANFRA
         masked=water
         fill_missing=0.
         rel_path = default:nlcd2011_can_ll_9s/
+        flag_in_output=FLAG_CANFRA
 ===============================
 name=CROPTYPE
         priority=1

--- a/geogrid/GEOGRID.TBL.ARW_CHEM
+++ b/geogrid/GEOGRID.TBL.ARW_CHEM
@@ -376,6 +376,7 @@ name = VAR_SSO
         rel_path =        5m:varsso_5m/
         rel_path =        10m:varsso_10m/
         rel_path =        default:varsso_10m/
+        flag_in_output=FLAG_VAR_SSO
 ===============================
 name = LAKE_DEPTH
         priority=1
@@ -395,6 +396,7 @@ name=URB_PARAM
         z_dim_name=num_urb_params
         interp_option=default:nearest_neighbor
         rel_path=default:NUDAPT44_1km/
+        flag_in_output=FLAG_URB_PARAM
 ===============================
 name=FRC_URB2D
         priority=1

--- a/geogrid/GEOGRID.TBL.FIRE
+++ b/geogrid/GEOGRID.TBL.FIRE
@@ -362,6 +362,7 @@ name = VAR_SSO
         rel_path =        5m:varsso_5m/
         rel_path =        10m:varsso_10m/
         rel_path =        default:varsso_10m/
+        flag_in_output=FLAG_VAR_SSO
 ===============================
 name = LAKE_DEPTH
         priority=1
@@ -381,6 +382,7 @@ name=URB_PARAM
         z_dim_name=num_urb_params
         interp_option=default:nearest_neighbor
         rel_path=default:NUDAPT44_1km/
+        flag_in_output=FLAG_URB_PARAM
 ===============================
 name=FRC_URB2D
         priority=1


### PR DESCRIPTION
These flags are passed through geogrid to metgrid. The program
that really cares about them is the real-data pre-peocessor,
real.exe. Given certain physical parameterization settings, the
lack of data (information provided by these flags) is used to
warn a user of problems.