### PR TITLE
Add additional logic in arch/preamble for finding WRF source directory

### DIFF
--- a/arch/preamble
+++ b/arch/preamble
@@ -33,14 +33,26 @@ PERL			=	perl
 RANLIB			=	echo
 
 #
-# Set path to compiled WRF code, which is assumed to be ../WRF for v4.x, or ../WRFV3 for v3.x
+# Look for compiled WRF code in one of several directories: WRF-4.0.1, WRF-4.0, WRF, and WRFV3.
+# The need for complicated logic to do this arises from the various names that the WRF code may take
+# on, depending on whether it was obtained through a GitHub archive file, as a clone of the GitHub
+# repository, or an older WRF v3.x tar file.
 # To override the path to the compiled WRF code, just set the WRF_DIR variable after the "endif" below
 #
-ifneq ($(wildcard $(DEV_TOP)/../WRF), ) # Check for WRF v4.x directory
-	WRF_DIR		=	../WRF
+ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0.1), ) # Check for WRF v4.0.1 directory (probably GitHub archive)
+	WRF_DIR = ../WRF-4.0.1
 else
-	WRF_DIR		=	../WRFV3
+ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0), )   # Check for WRF v4.0 directory (probably GitHub archive)
+	WRF_DIR = ../WRF-4.0
+else
+ifneq ($(wildcard $(DEV_TOP)/../WRF), )       # Check for clone of the WRF repository
+	WRF_DIR = ../WRF
+else                                          # Check for old WRF v3.x directory
+	WRF_DIR = ../WRFV3
 endif
+endif
+endif
+
 
 WRF_INCLUDE     =       -I$(WRF_DIR)/external/io_netcdf \
                         -I$(WRF_DIR)/external/io_grib_share \


### PR DESCRIPTION
Add additional logic in `arch/preamble` for finding the WRF source directory

The make logic in `arch/preamble` for setting the `WRF_DIR` variable to the location
of the compiled WRF source code previously looked either for a directory named
`../WRF` or a directory named `../WRFV3`. In anticipation of users downloading
the WRF code as a GitHub archive file, which will unpack to a name like
`WRF-4.0.1`, we need more sophisticated logic for finding this directory.

This commit adds checks for the WRF code in `../WRF-4.0.1` and `../WRF-4.0`.
In future we will likely need a more general solution (e.g., to handle the
eventual WRF 4.1 release), but as an immediate fix, checking for the WRF
4.0 or 4.0.1 releases should be sufficient.