### PR TITLE
Update default path to geog data on /glade filesystem on NWSC Cheyenne

### DIFF
--- a/namelist.wps
+++ b/namelist.wps
@@ -36,7 +36,7 @@
  truelat1  =  30.0,
  truelat2  =  60.0,
  stand_lon = -98.0,
- geog_data_path = '/glade/p/work/wrfhelp/WPS_GEOG/'
+ geog_data_path = '/glade/work/wrfhelp/WPS_GEOG/'
 /
 
 &ungrib

--- a/namelist.wps.all_options
+++ b/namelist.wps.all_options
@@ -59,7 +59,7 @@
  truelat1  =  30.0,
  truelat2  =  60.0,
  stand_lon = -98.0,
- geog_data_path = '/glade/p/work/wrfhelp/WPS_GEOG/'
+ geog_data_path = '/glade/work/wrfhelp/WPS_GEOG/'
  opt_geogrid_tbl_path = 'geogrid/'
 /
  geog_data_res     = 'modis_lakes+10m','modis_lakes+2m',

--- a/namelist.wps.fire
+++ b/namelist.wps.fire
@@ -42,7 +42,7 @@
  truelat1  =  39.338,
  truelat2  =  39.338,
  stand_lon = -106.807,
- geog_data_path = '/glade/p/work/wrfhelp/WPS_GEOG/'
+ geog_data_path = '/glade/work/wrfhelp/WPS_GEOG/'
 /
 
 &ungrib

--- a/namelist.wps.global
+++ b/namelist.wps.global
@@ -32,7 +32,7 @@
  stand_lon = 0.
  pole_lat = 90.0
  pole_lon = 0.0
- geog_data_path = '/glade/p/work/wrfhelp/WPS_GEOG/'
+ geog_data_path = '/glade/work/wrfhelp/WPS_GEOG/'
 /
  ref_lat = 45.0
  ref_lon = -98

--- a/namelist.wps.nmm
+++ b/namelist.wps.nmm
@@ -20,7 +20,7 @@
  map_proj = 'rotated_ll',
  ref_lat   =  42.00,
  ref_lon   = -71.00,
- geog_data_path = '/glade/p/work/wrfhelp/WPS_GEOG/'
+ geog_data_path = '/glade/work/wrfhelp/WPS_GEOG/'
 /
 
 &ungrib


### PR DESCRIPTION
Update default path to geog data on `/glade` filesystem on NWSC Cheyenne

The default path to the static geographical data previously pointed to
the `/glade/p/work` filesystem on the NWSC Cheyenne cluster. The `/glade` filesystem
was recently restructured so that `/glade/p/work` no longer exists.

Now, the geographical datasets are available in `/glade/work/wrfhelp/WPS_GEOG`.