### PR TITLE
Cray: compack.f, Grib2 fixed vs free format, illegal use of "&"

### DIFF
--- a/ungrib/src/ngl/g2/compack.f
+++ b/ungrib/src/ngl/g2/compack.f
@@ -254,7 +254,7 @@
      &                  kbit,novref,lbitref,ier)
            if(ier/=0) then
               ! Dr. Glahn's algorithm failed; use simple packing method instead.
- 1099         format('G2: fall back to simple algorithm (glahn ier=',I0,&
+ 1099         format('G2: fall back to simple algorithm (glahn ier=',I0,
      &               ')')
               print 1099,ier
               ngroups=ndpts/10


### PR DESCRIPTION
This is a fixed format file. There was a trailing "&" and no acceptable character in column 6 of
the continuing line. 

The trailing "&" was removed, and column six on the continuing line now sports a spiffy "&".

With the Cray ftn compiler, without this mod, the code does not compile. When using this mod,
this routine compiles. Other compilers let this slide through the cracks.