### PR TITLE
Cray mods: rrpr.F needs write statement clean-up

### DIFF
--- a/ungrib/src/rrpr.F
+++ b/ungrib/src/rrpr.F
@@ -1196,8 +1196,8 @@ subroutine vntrp(plvl, maxlvl, k, k2, interp_type, name, ix, jx)
   real :: frc
   integer :: interp_type
 
-  write(*,'("Interpolating to fill in ", A, " at level ", F8.2, " hPa using levels ", F8.2," hPa and ", &
-            F8.2," hPa")') trim(name), plvl(k)/100.0,plvl(k-1)/100.0, plvl(k2)/100.0
+  write(*,'("Interpolating to fill in ", A, " at level ", F8.2, " hPa using levels ", F8.2," hPa and ",& 
+     & F8.2," hPa")') trim(name), plvl(k)/100.0,plvl(k-1)/100.0, plvl(k2)/100.0
   call mprintf(.true.,INFORM, &
     "RRPR: Interpolating to fill in %s at %i Pa using levels %i Pa and %i Pa",&
     s1=trim(name), i1=int(plvl(k)), i2=int(plvl(k-1)), i3=int(plvl(k2)))


### PR DESCRIPTION
This is a fix for the Cray ftn compiler.

This is a free-format file. The proper syntax when splitting a string across more than one line is
to end each line with an "&" character and to also start the next line with an "&" character.

For example, we want this:
long_char = 'This is a lon&
                     &g string across mult&
                     &iple lines'

The original code did not include the leading "&" character on the following line.