### PR TITLE
Update version number to 4.0.2 in geogrid and metgrid global attributes

### DIFF
--- a/geogrid/src/process_tile_module.F
+++ b/geogrid/src/process_tile_module.F
@@ -300,7 +300,7 @@ module process_tile_module
       end if
 
       ! Initialize the output module now that we have the corner point lats/lons
-      call output_init(which_domain, 'OUTPUT FROM GEOGRID V4.0.1', '0000-00-00_00:00:00', grid_type, dynopt, &
+      call output_init(which_domain, 'OUTPUT FROM GEOGRID V4.0.2', '0000-00-00_00:00:00', grid_type, dynopt, &
                        corner_lats, corner_lons, &
                        start_dom_i,   end_dom_i,   start_dom_j,   end_dom_j, &
                        start_patch_i, end_patch_i, start_patch_j, end_patch_j, &

--- a/metgrid/src/input_module.F
+++ b/metgrid/src/input_module.F
@@ -427,7 +427,9 @@ module input_module
 #endif
      
          call ext_get_dom_ti_char          ('TITLE', title)
-         if (index(title,'GEOGRID V4.0.1') /= 0) then
+         if (index(title,'GEOGRID V4.0.2') /= 0) then
+            wps_version = 4.02
+         else if (index(title,'GEOGRID V4.0.2') /= 0) then
             wps_version = 4.01
          else if (index(title,'GEOGRID V4.0') /= 0) then
             wps_version = 4.0

--- a/metgrid/src/process_domain_module.F
+++ b/metgrid/src/process_domain_module.F
@@ -876,7 +876,7 @@ integer, parameter :: BDR_WIDTH = 3
       !   now we simply output every field from the storage module.
       !
     
-      title = 'OUTPUT FROM METGRID V4.0.1' 
+      title = 'OUTPUT FROM METGRID V4.0.2' 
    
       ! Initialize the output module for this domain and time
       call mprintf(.true.,LOGFILE,'Initializing output module.')


### PR DESCRIPTION
This merge updates the version number to 4.0.2 in geogrid and metgrid output.

The 'TITLE' global attribute in geogrid and metgrid output files now contains
the version number "V4.0.2".
