### PR TITLE
Add additional logic in arch/preamble for finding WRF-4.0.2 source directory

### DIFF
--- a/arch/preamble
+++ b/arch/preamble
@@ -33,12 +33,15 @@ PERL			=	perl
 RANLIB			=	echo
 
 #
-# Look for compiled WRF code in one of several directories: WRF-4.0.1, WRF-4.0, WRF, and WRFV3.
+# Look for compiled WRF code in one of several directories: WRF-4.0.2, WRF-4.0.1, WRF-4.0, WRF, and WRFV3.
 # The need for complicated logic to do this arises from the various names that the WRF code may take
 # on, depending on whether it was obtained through a GitHub archive file, as a clone of the GitHub
 # repository, or an older WRF v3.x tar file.
 # To override the path to the compiled WRF code, just set the WRF_DIR variable after the "endif" below
 #
+ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0.2), ) # Check for WRF v4.0.2 directory (probably GitHub archive)
+	WRF_DIR = ../WRF-4.0.2
+else
 ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0.1), ) # Check for WRF v4.0.1 directory (probably GitHub archive)
 	WRF_DIR = ../WRF-4.0.1
 else
@@ -49,6 +52,7 @@ ifneq ($(wildcard $(DEV_TOP)/../WRF), )       # Check for clone of the WRF repos
 	WRF_DIR = ../WRF
 else                                          # Check for old WRF v3.x directory
 	WRF_DIR = ../WRFV3
+endif
 endif
 endif
 endif


### PR DESCRIPTION
This merge adds additional logic in arch/preamble to finding the WRF-4.0.2 source.

Similar to what was done in c701b7e6, we need to update logic in arch/preamble
for setting the WRF_DIR variable to handle WRF source code that may be found
in a directory named WRF-4.0.2.

As mentioned in the commit message for c701b7e6, a more general solution to
finding the WRF source is needed to avoid growing complexity of the logic
in arch/preamble.