### PR TITLE
Correct inconsequential bug in detection of geogrid v4.0.1 output

### DIFF
--- a/metgrid/src/input_module.F
+++ b/metgrid/src/input_module.F
@@ -429,7 +429,7 @@ module input_module
          call ext_get_dom_ti_char          ('TITLE', title)
          if (index(title,'GEOGRID V4.0.2') /= 0) then
             wps_version = 4.02
-         else if (index(title,'GEOGRID V4.0.2') /= 0) then
+         else if (index(title,'GEOGRID V4.0.1') /= 0) then
             wps_version = 4.01
          else if (index(title,'GEOGRID V4.0') /= 0) then
             wps_version = 4.0


### PR DESCRIPTION
This merge corrects an inconsequential bug in the detection of geogrid v4.0.1
output by the metgrid v4.0.2 program.

The metgrid program attempts to detect the version of the geogrid files
that it is reading (e.g., because certain fields and attributes may only
be present after a certain version of geogrid). Commit f0f4473c introduced
a bug wherein geogrid v4.0.1 output was not handled as expected, and was
detected by metgrid as v4.0. While completely harmless (since there were
no changes to fields or attributes in geogrid output between v4.0 and
v4.0.1), it's easy enough to fix this.