### PR TITLE
Remove -f90= and -cc= options from MPI wrappers

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -61,8 +61,8 @@ COMPRESSION_INC     = CONFIGURE_COMP_I
 FDEFS               = CONFIGURE_FDEFS
 SFC                 = ifort
 SCC                 = icc
-DM_FC               = mpif90 -f90=ifort
-DM_CC               = mpicc -cc=icc
+DM_FC               = mpif90
+DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC 
 LD                  = $(FC)
@@ -85,8 +85,8 @@ COMPRESSION_INC     = CONFIGURE_COMP_I
 FDEFS               = CONFIGURE_FDEFS
 SFC                 = g95
 SCC                 = gcc
-DM_FC               = mpif90 -f90=g95
-DM_CC               = mpicc -cc=gcc
+DM_FC               = mpif90
+DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC 
 LD                  = $(FC)
@@ -109,8 +109,8 @@ COMPRESSION_INC     = CONFIGURE_COMP_I
 FDEFS               = CONFIGURE_FDEFS
 SFC                 = gfortran
 SCC                 = gcc
-DM_FC               = mpif90 -f90=gfortran
-DM_CC               = mpicc -cc=gcc 
+DM_FC               = mpif90
+DM_CC               = mpicc
 FC                  = CONFIGURE_FC 
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
@@ -132,8 +132,8 @@ COMPRESSION_INC     = CONFIGURE_COMP_I
 FDEFS               = CONFIGURE_FDEFS
 SFC                 = gfortran
 SCC                 = gcc
-DM_FC               = mpif90 -f90=gfortran
-DM_CC               = mpicc -cc=gcc 
+DM_FC               = mpif90
+DM_CC               = mpicc
 FC                  = CONFIGURE_FC 
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
@@ -231,8 +231,8 @@ COMPRESSION_INC     = CONFIGURE_COMP_I
 FDEFS               = CONFIGURE_FDEFS
 SFC                 = ifort
 SCC                 = icc
-DM_FC               = mpif90 -f90=ifort
-DM_CC               = mpicc -cc=icc
+DM_FC               = mpif90
+DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
@@ -328,8 +328,8 @@ COMPRESSION_INC     = CONFIGURE_COMP_I
 FDEFS               = CONFIGURE_FDEFS
 SFC                 = pgf90
 SCC                 = pgcc
-DM_FC               = mpif90 -f90=pgf90
-DM_CC               = mpicc -cc=pgcc
+DM_FC               = mpif90
+DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)


### PR DESCRIPTION
This merge corrects build warnings and errors caused by the use of `-f90=`
and `-cc=` options with the MPI compiler wrappers. Examples include:
```
gfortran: error: unrecognized command line option ‘-f90=gfortran’

ifort: command line warning #10006: ignoring unknown option '-f90=ifort'

pgfortran-Error-Unknown switch: -f90=pgf90
```

Depending on the MPI implementation, it appear that the mpif90 and mpicc
wrappers may or may not pass the `-f90=` and `-cc=` options directly to
the underlying compiler, where these options may generate either warnings
or errors.

The original intent of using, e.g., `mpif90 -f90=gfortran` was to permit
this use of a different Fortran compiler than the default selected by
the MPI wrapper. However, this appears to be not widely supported, and
it may be preferable to just remove these options and to assume that
the default compilers selected by the MPI wrappers are correct.

Note: The `-f90=` and `-cc=` options have not been removed from stanzas that
will likely be deprecated in future, either because the hardware is no longer
produced (PowerPC Apple hardware) or the compiler is no longer being
developed (g95 and PathScale).