### PR TITLE
Add extensible logic for finding WRF build, e.g., in ../WRF-4.0.3

### DIFF
--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -7,6 +7,7 @@
 # the appropriate options for the type of machine, and the OS, and the compiler!
 
 $sw_perl_path   = perl;
+$sw_wrf_path   = "<SET ME>";
 $sw_netcdf_path = "";
 $sw_netcdff_lib = "";
 $sw_phdf5_path  = ""; 
@@ -28,6 +29,10 @@ while(substr( $ARGV[0], 0, 1 ) eq "-")
     if(substr( $ARGV[0], 1, 5 ) eq "perl=")
     {
         $sw_perl_path = substr( $ARGV[0], 6);
+    }
+    if(substr( $ARGV[0], 1, 7 ) eq "wrfdir=")
+    {
+        $sw_wrf_path = substr( $ARGV[0], 8);
     }
     if(substr( $ARGV[0], 1, 7 ) eq "netcdf=")
     {
@@ -296,6 +301,7 @@ open CONFIGURE_WRF, "> configure.wps" || die "cannot Open for writing... configu
         }
 
         $_ =~ s:CONFIGURE_NETCDFF_LIB:$sw_netcdff_lib:g; 
+        $_ =~ s:CONFIGURE_WRF_PATH:$sw_wrf_path:g; 
         @preamble = ( @preamble, $_ ) ;
     }
     close ARCH_PREAMBLE;

--- a/arch/preamble
+++ b/arch/preamble
@@ -33,12 +33,15 @@ PERL			=	perl
 RANLIB			=	echo
 
 #
-# Look for compiled WRF code in one of several directories: WRF-4.0.2, WRF-4.0.1, WRF-4.0, WRF, and WRFV3.
+# Look for compiled WRF code in one of several directories: WRF-4.0.3, WRF-4.0.2, WRF-4.0.1, WRF-4.0, WRF, and WRFV3.
 # The need for complicated logic to do this arises from the various names that the WRF code may take
 # on, depending on whether it was obtained through a GitHub archive file, as a clone of the GitHub
 # repository, or an older WRF v3.x tar file.
 # To override the path to the compiled WRF code, just set the WRF_DIR variable after the "endif" below
 #
+ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0.3), ) # Check for WRF v4.0.3 directory (probably GitHub archive)
+	WRF_DIR = ../WRF-4.0.3
+else
 ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0.2), ) # Check for WRF v4.0.2 directory (probably GitHub archive)
 	WRF_DIR = ../WRF-4.0.2
 else
@@ -52,6 +55,7 @@ ifneq ($(wildcard $(DEV_TOP)/../WRF), )       # Check for clone of the WRF repos
 	WRF_DIR = ../WRF
 else                                          # Check for old WRF v3.x directory
 	WRF_DIR = ../WRFV3
+endif
 endif
 endif
 endif

--- a/arch/preamble
+++ b/arch/preamble
@@ -32,35 +32,7 @@ PERL			=	perl
 
 RANLIB			=	echo
 
-#
-# Look for compiled WRF code in one of several directories: WRF-4.0.3, WRF-4.0.2, WRF-4.0.1, WRF-4.0, WRF, and WRFV3.
-# The need for complicated logic to do this arises from the various names that the WRF code may take
-# on, depending on whether it was obtained through a GitHub archive file, as a clone of the GitHub
-# repository, or an older WRF v3.x tar file.
-# To override the path to the compiled WRF code, just set the WRF_DIR variable after the "endif" below
-#
-ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0.3), ) # Check for WRF v4.0.3 directory (probably GitHub archive)
-	WRF_DIR = ../WRF-4.0.3
-else
-ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0.2), ) # Check for WRF v4.0.2 directory (probably GitHub archive)
-	WRF_DIR = ../WRF-4.0.2
-else
-ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0.1), ) # Check for WRF v4.0.1 directory (probably GitHub archive)
-	WRF_DIR = ../WRF-4.0.1
-else
-ifneq ($(wildcard $(DEV_TOP)/../WRF-4.0), )   # Check for WRF v4.0 directory (probably GitHub archive)
-	WRF_DIR = ../WRF-4.0
-else
-ifneq ($(wildcard $(DEV_TOP)/../WRF), )       # Check for clone of the WRF repository
-	WRF_DIR = ../WRF
-else                                          # Check for old WRF v3.x directory
-	WRF_DIR = ../WRFV3
-endif
-endif
-endif
-endif
-endif
-
+WRF_DIR = CONFIGURE_WRF_PATH
 
 WRF_INCLUDE     =       -I$(WRF_DIR)/external/io_netcdf \
                         -I$(WRF_DIR)/external/io_grib_share \

--- a/configure
+++ b/configure
@@ -150,8 +150,47 @@ if [ $? -eq 0 ] ; then
     fi
 fi
 
+wrf_dir="none"
+standard_wrf_dirs="WRF WRF-4.0.3 WRF-4.0.2 WRF-4.0.1 WRF-4.0 WRFV3"
+
+#
+# If no WRF_DIR environment variable is set, try to locate a WRF build in one
+# of the expected directory names one directory level up; otherwise, try to use
+# the WRF I/O library from the code in $WRF_DIR
+#
+if [ -z "$WRF_DIR" ]; then
+#   for d in WRF WRF-4.0.3 WRF-4.0.2 WRF-4.0.1 WRF-4.0 WRFV3; do
+   for d in ${standard_wrf_dirs}; do
+      if [ -e ../${d}/external/io_netcdf/libwrfio_nf.a ]; then
+         echo "Found what looks like a valid WRF I/O library in ../${d}"
+         wrf_dir="../${d}"
+         break
+      fi
+   done
+else
+   if [ ! -e ${WRF_DIR}/external/io_netcdf/libwrfio_nf.a ]; then
+      echo ""
+      echo "Error: The \$WRF_DIR environment variable was set, but the WRF code at"
+      echo "       ${WRF_DIR} doesn't appear to have been successfully compiled"
+      echo ""
+      exit
+   fi
+
+   echo "Using WRF I/O library in WRF build identified by \$WRF_DIR: ${WRF_DIR}"
+   wrf_dir=$WRF_DIR
+fi
+
+if [ $wrf_dir == "none" ]; then
+   echo ""
+   echo "Error: No compiled WRF code found. Please check that the WRF model has been compiled"
+   echo "       one directory level up (i.e., ../) in a directory named 'WRF', 'WRF-4.0.3', 'WRF-4.0.2', etc.,"
+   echo "       or specify the full path to the compiled WRF model with the environment variable \$WRF_DIR ."
+   echo ""
+   exit
+fi
+
 # Found perl, so proceed with configuration
-perl arch/Config.pl -perl=$PERL -netcdf=$NETCDF -netcdff=$NETCDFF -os=$os -mach=$mach 
+perl arch/Config.pl -perl=$PERL -netcdf=$NETCDF -netcdff=$NETCDFF -os=$os -mach=$mach -wrfdir=$wrf_dir
 
 
 #Checking cross-compiling capability for some particular environment 


### PR DESCRIPTION
This merge replaces the logic in `arch/preamble` for locating compiled WRF source
code with more extensible logic in the `configure` script.

The path to the compiled WRF source can now be specified by the environment
variable `$WRF_DIR`, or an attempt will be made to find the compiled source in
`../WRF-4.0.3`, `../WRF-4.0.2`, ..., `WRFV3`.