### PR TITLE
Change Vtable.GFS so the default sea level pressure is MSLET

### DIFF
--- a/ungrib/Variable_Tables/Vtable.GFS
+++ b/ungrib/Variable_Tables/Vtable.GFS
@@ -11,7 +11,7 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
   33 | 105  |  10  |      | UU       | m s-1   | U                 at 10 m               |  0  |  2  |  2  | 103 |
   34 | 105  |  10  |      | VV       | m s-1   | V                 at 10 m               |  0  |  2  |  3  | 103 |
    1 |   1  |   0  |      | PSFC     | Pa      | Surface Pressure                        |  0  |  3  |  0  |   1 |
-   2 | 102  |   0  |      | PMSL     | Pa      | Sea-level Pressure                      |  0  |  3  |  1  | 101 |
+ 130 | 102  |   0  |      | PMSL     | Pa      | Sea-level Pressure                      |  0  |  3  | 192 | 101 |
  144 | 112  |   0  |  10  | SM000010 | fraction| Soil Moist 0-10 cm below grn layer (Up) |  2  |  0  | 192 | 106 |
  144 | 112  |  10  |  40  | SM010040 | fraction| Soil Moist 10-40 cm below grn layer     |  2  |  0  | 192 | 106 |
  144 | 112  |  40  | 100  | SM040100 | fraction| Soil Moist 40-100 cm below grn layer    |  2  |  0  | 192 | 106 |
@@ -68,3 +68,9 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
 #
 #  As of mid-2017 the GFS provides two land mask fields in the pressure-level output. WPS uses LANDN if available
 #  and renames it LANDSEA.
+#
+#  As of WPS V4.0.3 the default PMSL is changed to MSLET. MSLET is an unsmoothed sea level pressure.
+#  NCEP included MSLET in their GFS files beginning 12z on 10 May 2011 and in their GDAS files at 12z 14 January 2015.
+#  The smoother PRMSL is in all GFS/GDAS pressure files.
+#  For GFS files prior to those dates use PRMSL as shown in the following line:
+#  2 | 102  |   0  |      | PMSL     | Pa      | Sea-level Pressure                      |  0  |  3  |  1  | 101 |


### PR DESCRIPTION
Replaces PR #97 "Change Vtable.GFS so the default sea level pressure is MSLET - BAD HISTORY"

NCEP has included the MSLET sea level pressure field in its pressure-level
grib files since May 10, 2011. This is in addition to the PRMSL sea level
pressure field (the previous default SLP in WPS). The PRMSL field is
smoothed/truncated. For the lower horizontal resolutions of GFS output in
years past this wasn't a significant issue. For the current higher
resolutions, the smoothing is very noticeable. (See attached figures).
SLP may be used to compute surface pressure in real. WRF tests with this
change show only minor differences. The main impact of using MSLET instead
of PRMSL is if metgrid output is used for plotting or verification.

Impact on the SLP field outside the areas of tropical storms:
Any system with a small-scale minimum or maximum will be smoothed away in
PRMSL. Practically, only cyclones (tropical or extratropical) have a
noticeable difference with the new field.

The only file changed is the GFS Vtable. The new SLP field is provided and the old
SLP field is deleted. A message is provided to users on how to get the original SLP
field.

Running the two different Vtable.GFS files (before vs after mods), the only field that
changes is PMSL.

The smoothed field (top figure) is PRMSL which is the current default.
The bottom figure is MSLET the proposed default SLP field in WPS.

SMOOTHED SLP
![met2](https://user-images.githubusercontent.com/20980146/50380790-5d002c00-0630-11e9-8d01-1399cfbf661b.gif)

UN-SMOOTHED SLP
![met3](https://user-images.githubusercontent.com/20980146/50380791-625d7680-0630-11e9-920c-e95109850181.gif)