### PR TITLE
Add LOGSFP entry to METGRID.TBL.ARW

### DIFF
--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -1034,3 +1034,9 @@ mpas_name=tslb
         masked=water
         fill_missing=1.
 ========================================
+# Typically from ECMWF model-level data and used by calc_ecmwf_p.exe
+# Not needed by WRF
+name=LOGSFP
+        output=no
+        interp_option=four_pt
+========================================


### PR DESCRIPTION
Model-level ECMWF datasets typically provide a logarithm of the surface
pressure, which may be used by the calc_ecmwf_p utility to produce a full 3-d
pressure field. In order to silence warnings from metgrid when the LOGSFP field
is found in intermediate files, this commit adds an entry to the METGRID.TBL.ARW
file for this field. Since the LOGSFP field is not used by WRF, the "output=no"
specification is also added to the LOGSFP entry.