### PR TITLE
Adjust pressure-level RH from GEFS as is done for GFS, CDAS, and ECMWF.

### DIFF
--- a/ungrib/src/rrpr.F
+++ b/ungrib/src/rrpr.F
@@ -588,6 +588,7 @@ subroutine rrpr(hstart, ntimes, interval, nlvl, maxlvl, plvl, &
 
 ! Repair GFS and ECMWF pressure-level RH
         if (index(map%source,'NCEP GFS') .ne. 0 .or.  &
+            index(map%source,'NCEP GEFS') .ne. 0 .or. &
             index(map%source,'NCEP CDAS CFSV2') .ne. 0 .or.  &
             index(map%source,'ECMWF') .ne. 0 ) then
           call mprintf(.true.,DEBUG, &


### PR DESCRIPTION
Wei discovered that GEFS RH is not w.r.t. water (as the WRF/WPS system expects).
Therefore, it needs to be treated like the regular GFS. Before adjustment,
there are large areas of supersaturation in the upper troposphere where
temperatures are below -10C or so. After the fix, RHs are correct.