### PR TITLE
Fix mismatch integer kind in IAND intrinsic calls in g2 library

### DIFF
--- a/ungrib/src/ngl/g2/intmath.f
+++ b/ungrib/src/ngl/g2/intmath.f
@@ -169,7 +169,7 @@
       ilog2_2=0
       i=i_in
       if(i<=0) return
-      if(iand(i,i-1)/=0) then
+      if(iand(i,i-1_2)/=0) then
          !write(0,*) 'iand i-1'
          ilog2_2=1
       endif
@@ -204,7 +204,7 @@
       ilog2_1=0
       i=i_in
       if(i<=0) return
-      if(iand(i,i-1)/=0) then
+      if(iand(i,i-1_1)/=0) then
          !write(0,*) 'iand i-1'
          ilog2_1=1
       endif

--- a/ungrib/src/ngl/g2/intmath.f
+++ b/ungrib/src/ngl/g2/intmath.f
@@ -169,6 +169,8 @@
       ilog2_2=0
       i=i_in
       if(i<=0) return
+! WPS modification for the XL compiler
+!      if(iand(i,i-1)/=0) then
       if(iand(i,i-1_2)/=0) then
          !write(0,*) 'iand i-1'
          ilog2_2=1
@@ -204,6 +206,8 @@
       ilog2_1=0
       i=i_in
       if(i<=0) return
+! WPS modification for the XL compiler
+!      if(iand(i,i-1)/=0) then
       if(iand(i,i-1_1)/=0) then
          !write(0,*) 'iand i-1'
          ilog2_1=1


### PR DESCRIPTION
The calls to the IAND intrinsic in the g2 library's ilog2_2 and ilog2_1
function used arguments of 'i' and 'i-1', where 'i' is of kind=2 or kind=1.
The XL compiler fails to compile this code with the complaint that
the arguments to IAND are of mismatched kind. It appears that 'i-1' is
being promoted to the default integer kind, unless we declare the constant
with _2 or _1.