### PR TITLE
Fix string comparison

### DIFF
--- a/configure
+++ b/configure
@@ -180,7 +180,7 @@ else
    wrf_dir=$WRF_DIR
 fi
 
-if [ $wrf_dir == "none" ]; then
+if [ $wrf_dir = "none" ]; then
    echo ""
    echo "Error: No compiled WRF code found. Please check that the WRF model has been compiled"
    echo "       one directory level up (i.e., ../) in a directory named 'WRF', 'WRF-4.0.3', 'WRF-4.0.2', etc.,"


### PR DESCRIPTION
There is an error when == operator is used with single square brackets:

+ [ ../WRF == none ]
./configure: 183: [: ../WRF: unexpected operator

According to:
https://unix.stackexchange.com/questions/382003/what-are-the-differences-between-and-in-conditional-expressions

The = operator is the POSIX compatible way of comparing strings in sh/test.

I think there are 2 ways of comparing strings:
if [ $wrf_dir = "none" ]; then
if [[ $wrf_dir == "none" ]]; then