### PR TITLE
METGRID.TBL.ARW default pass QNC variable

### DIFF
--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -689,7 +689,6 @@ mpas_name=ni
         flag_in_output=FLAG_QNI
 ========================================
 name=QNC
-        output=no
         interp_option=four_pt+average_4pt
         fill_missing=0.
         fill_lev=200100:const(0.)


### PR DESCRIPTION
There appears to be an errant output=no on the variable=QNC (cloud droplet number 
concentration) that can be removed from the metgrid/METGRID.TBL file. This is specifically
for those WPS users attempting to pass cloud mass and cloud number concentration from 
RAP/HRRR native model level files into real. 

The real program is able to correctly handle these fields due to the flags already in use in the
QNC stanza in the METGRID.TBL file.