### PR TITLE
Update VariableTable microphys variables from HRRR/RAP newer versions

### DIFF
--- a/ungrib/Variable_Tables/Vtable.RAP.hybrid.ncep
+++ b/ungrib/Variable_Tables/Vtable.RAP.hybrid.ncep
@@ -9,15 +9,18 @@ Param| Type |Level1|Level2| Name     |  Units   | Description                   
   34 | 109  |   *  |      | VV       | m s-1    | V                                       |  0  |  2  |  3  | 105 |
  153 | 109  |   *  |      | QC       | kg kg-1  | Cloud water mixing ratio                |  0  |  1  | 22  | 105 |
  170 | 109  |   *  |      | QR       | kg kg-1  | Rain water mixing ratio                 |  0  |  1  | 24  | 105 |
-  58 | 109  |   *  |      | QI       | kg kg-1  | Ice mixing ratio                        |  0  |  6  |  0  | 105 |
+  58 | 109  |   *  |      | QI       | kg kg-1  | Ice mixing ratio                        |  0  |  1  | 82  | 105 |
  171 | 109  |   *  |      | QS       | kg kg-1  | Snow water mixing ratio                 |  0  |  1  | 25  | 105 |
  179 | 109  |   *  |      | QG       | kg kg-1  | Graupel mixing ratio                    |  0  |  1  | 32  | 105 |
- 148 | 107  |   *  |      | QNR      | kg-1     | Rain number concentration               |  0  |  3  | 195 | 105 |
- 198 | 109  |   *  |      | QNI      | kg-1     | Ice number concentration                |  0  |  1  | 207 | 105 |
+ 153 | 109  |   *  |      | QNR      | kg-1     | Rain number concentration               |  0  |  1  | 100 | 105 |
+ 255 | 109  |   *  |      | QNC      | kg-1     | Cloud number concentration              |  0  |  6  | 28  | 105 |
+ 198 | 109  |   *  |      | QNI      | kg-1     | Ice number concentration                |  0  |  6  | 29  | 105 |
+ 157 | 107  |   *  |      | QNWFA    | kg-1     | Water-fr. aerosol number concentration  |  0  | 13  | 193 | 105 |
+ 156 | 107  |   *  |      | QNIFA    | kg-1     | Ice-fr.   aerosol number concentration  |  0  | 13  | 192 | 105 |
      | 109  |   *  |      | RH       | %        | Relative Humidity                       |  0  |  1  |     | 105 |
   11 | 105  |   2  |      | TT       | K        | Temperature at 2 m                      |  0  |  0  |  0  | 103 |
   51 | 105  |   2  |      | SPECHUMD | kg kg-1  | Specific Humidity at 2 m                |  0  |  1  |  0  | 103 |
-     | 105  |   2  |      | RH       | %        | Relative Humidity at 2 m                |  0  |  1  |     | 103 |
+  52 | 105  |   2  |      | RH       | %        | Relative Humidity at 2 m                |  0  |  1  |  1  | 103 |
   33 | 105  |  10  |      | UU       | m s-1    | U at 10 m                               |  0  |  2  |  2  | 103 |
   34 | 105  |  10  |      | VV       | m s-1    | V at 10 m                               |  0  |  2  |  3  | 103 |
    1 |   1  |   0  |      | PSFC     | Pa       | Surface Pressure                        |  0  |  3  |  0  |   1 |

--- a/ungrib/Variable_Tables/Vtable.RAP.hybrid.ncep
+++ b/ungrib/Variable_Tables/Vtable.RAP.hybrid.ncep
@@ -61,7 +61,7 @@ Param| Type |Level1|Level2| Name     |  Units   | Description                   
 #  Vtable for the Rapid refresh (RAP) hybrid-vertical coordinate grib2 files on the ncep server.
 #  ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rap/prod/rap.ccyymmdd/
 #
-#  rap.txxz.awp130bgrbfhh.grib2   13km conus     15.5 MB (approximate size)
+#  rap.txxz.awp130bgrbfhh.grib2   13km conus     31 MB (approximate size)
 #
 #  As of 20 April, 2020
 #  hourly to 21 hours

--- a/ungrib/Variable_Tables/Vtable.RAP.hybrid.ncep
+++ b/ungrib/Variable_Tables/Vtable.RAP.hybrid.ncep
@@ -61,9 +61,8 @@ Param| Type |Level1|Level2| Name     |  Units   | Description                   
 #  Vtable for the Rapid refresh (RAP) hybrid-vertical coordinate grib2 files on the ncep server.
 #  ftp://ftpprd.ncep.noaa.gov/pub/data/nccf/com/rap/prod/rap.ccyymmdd/
 #
-#  rap.txxz.awp252bgrbfhh.grib2   20km conus     17901 Kb  (approx. size)
-#  rap.txxz.awp130bgrbfhh.grib2   13km conus     34462 Kb
+#  rap.txxz.awp130bgrbfhh.grib2   13km conus     15.5 MB (approximate size)
 #
-#  As of 1 June 2016,
-#  hourly to 18-hours
+#  As of 20 April, 2020
+#  hourly to 21 hours
 #  Level 1 is near the surface, level 50 is the top.


### PR DESCRIPTION
With the newer version of RAP and HRRR files from NCEP, the GRIB2 parameter codes have changed plus I have added *all* variables to be available related to microphysics (and aerosols).  These were tested with Jan-Mar 2019 actual stream of NCEP grib2 files I used in a real-time WRF run and I can validate all variables properly pass through to wrfinput_d0x (and wrfbdy_d0x).