### PR TITLE
Add 2001lvl qnwfa

### DIFF
--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -1013,12 +1013,16 @@ name=HGTMAXW
         flag_in_output=FLAG_HGTMAXW
 ========================================
 name=QNWFA
-        z_dim_name=num_qnwfa_levels
         interp_option=four_pt+average_4pt
+        fill_missing=100.E6
+        fill_lev=200100:const(100.E6)
+        flag_in_output=FLAG_QNIFA
 ========================================
 name=QNIFA
-        z_dim_name=num_qnwfa_levels
         interp_option=four_pt+average_4pt
+        fill_missing=1.E6
+        fill_lev=200100:const(1.E6)
+        flag_in_output=FLAG_QNIFA
 ========================================
 # This entry is only used for MPAS data
 name=smois

--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -1016,7 +1016,7 @@ name=QNWFA
         interp_option=four_pt+average_4pt
         fill_missing=100.E6
         fill_lev=200100:const(100.E6)
-        flag_in_output=FLAG_QNIFA
+        flag_in_output=FLAG_QNWFA
 ========================================
 name=QNIFA
         interp_option=four_pt+average_4pt


### PR DESCRIPTION
Existing entries of QNWFA and QNIFA variables coming from RAP/HRRR grib files are not treated same as all the microphysics variables with an extra fake surface level (2001.mb).  This brings those 2 variables to be consistent with the same number of vertical levels.  An alternative is to eliminate the fake surface level for all variables of cloud, rain, snow, etc. since it is falsified anyway; but this keeps the total number of levels for all incoming data the same as temperature, winds, humidity, etc.