### PR TITLE
Remove "(PRE-RELEASE)" from the version number in the README file

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-WRF Pre-Processing System Version 4.1 (PRE-RELEASE)
+WRF Pre-Processing System Version 4.1
 
 http://www2.mmm.ucar.edu/wrf/users/
 


### PR DESCRIPTION
This merge simply removes the "(PRE-RELEASE)" text from the README file in
preparation for the v4.1 release tag.