### PR TITLE
Add new irrigation dataset to GEOGRID.TBL

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -488,3 +488,12 @@ name = SANDFRAC
         rel_path = default:sandfrac_5m/
         flag_in_output=FLAG_SANDFRAC
 ===============================
+name=IRRIGATION
+        priority=1
+        optional=yes
+        dest_type=continuous
+        interp_option=irrfao:average_gcell(0.0)+average_4pt+nearest_neighbor
+        masked = water
+        fill_missing = 0.
+        rel_path=irrfao:irrigation/fao/
+===============================

--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -492,8 +492,8 @@ name=IRRIGATION
         priority=1
         optional=yes
         dest_type=continuous
-        interp_option=irrfao:average_gcell(0.0)+average_4pt+nearest_neighbor
+        interp_option=default:average_gcell(0.0)+average_4pt+nearest_neighbor
         masked = water
         fill_missing = 0.
-        rel_path=irrfao:irrigation/fao/
+        rel_path=default:irrigation/fao/
 ===============================


### PR DESCRIPTION
This PR adds a new dataset of irrigation to the table as an optional entry. This dataset is 
0.0833 degree (1/12 degree) resolution, about 9 km. The generated field, named irrigation, is a 2D field of actual percentages (0 - 100). 

In anticipation of other irrigation data sets becoming available, this data is located under 
the generic directory "irrigation" and then in the data-specific "fao" subdirectory.

The data is sourced from 
http://www.fao.org/aquastat/en/geospatial-information/global-maps-irrigated-areas. 

The dataset supports the new WRF model option sf_surf_irr_scheme =1, 2 and 3.

The following image is such a field over CONUS.

![irrigation_us](https://user-images.githubusercontent.com/12705680/76464468-0a34a080-63ab-11ea-8e0e-dcad54b9e098.png)
