### PR TITLE
Initialize arrays in calc_ecmwf_p to avoid potential error in GHT calculation

### DIFF
--- a/util/src/calc_ecmwf_p.F
+++ b/util/src/calc_ecmwf_p.F
@@ -235,6 +235,7 @@ program calc_ecmwf_p
 
                      if (.not. allocated(tt)) then
                         allocate(tt(ecmwf_data%nx,ecmwf_data%ny,n_levels+1))  ! Extra level is for surface
+                        tt(:,:,:) = 0.0
                      end if
 
                      if (nint(ecmwf_data%xlvl) >= 1 .and. &
@@ -249,6 +250,7 @@ program calc_ecmwf_p
 
                      if (.not. allocated(qv)) then
                         allocate(qv(ecmwf_data%nx,ecmwf_data%ny,n_levels+1))  ! Extra level is for surface
+                        qv(:,:,:) = 0.0
                      end if
 
                      if (nint(ecmwf_data%xlvl) >= 1 .and. &


### PR DESCRIPTION
This PR fixes a potential error in the calculation of the GHT field in
the calc_ecmwf_p utility due to the use of uninitialized memory.

When the calc_ecmwf_p utility is provided with a subset of ECMWF model levels,
it may happen that the allocated 'tt' array contains non-zero values (because
it was not previously initialized). This leads to errors in the calculation of
the GHT field due to the use of uninitialized memory.

Thanks to @hugohartmann for identifying this issue and suggesting the fix in
this PR.

This PR fixes issue #136 .