### PR TITLE
Fix scaling of starting latitude in GRIB2 datasets on a Gaussian grid

### DIFF
--- a/ungrib/src/g2print.F
+++ b/ungrib/src/g2print.F
@@ -562,7 +562,7 @@ end program g2print
               endif
 
               ! Scale lat/lon values to 0-180, default range is 1e6.
-              if (map%lat1.ge.scale_factor) then 
+              if (abs(map%lat1).ge.scale_factor) then 
                  map%lat1 = map%lat1/scale_factor
               endif
               if (map%lon1.ge.scale_factor) then 

--- a/ungrib/src/rd_grib2.F
+++ b/ungrib/src/rd_grib2.F
@@ -492,7 +492,7 @@ C  SET ARGUMENTS
               endif
 
               ! Scale lat/lon values to 0-180, default range is 1e6.
-              if (map%lat1.ge.scale_factor) then 
+              if (abs(map%lat1).ge.scale_factor) then
                  map%lat1 = map%lat1/scale_factor
               endif
               if (map%lon1.ge.scale_factor) then 


### PR DESCRIPTION
This PR fixes an issue in scaling the starting latitude in GRIB2 datasets on 
a Gaussian grid.

Prior to the changes in this PR, the code in rd_grib2.F compared the starting
latitude for a field on a Gaussian grid with the scaling factor, and if 
the starting latitude was larger than the scaling factor, the starting latitude
was scaled. However, this fails when the starting latitude is negative, in which
case no scaling is applied, and downstream code fails due to an invalid starting
latitude in the resulting intermediate file.

The fix in this PR is to simply compare the magnitude of the starting latitude 
with the scaling factor, and if the former exceeds the latter, then scaling of 
the starting latitude is performed.

Thanks to Linda Maoyi for identifying the issue addressed in this PR.

This PR fixes issue #142 .