### PR TITLE
Add -qufmt=be to FFLAGS and F77FLAGS for XL/POWER/Linux stanza

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -11,8 +11,8 @@ SFC                 = xlf2003_r
 CC                  = mpicc
 SCC                 = xlc_r
 LD                  = $(FC)
-FFLAGS              = -qfree=f90
-F77FLAGS            = -qfixed
+FFLAGS              = -qfree=f90 -qufmt=be
+F77FLAGS            = -qfixed -qufmt=be
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
 CFLAGS              =


### PR DESCRIPTION
This PR adds the `-qufmt=be` option to FFLAGS and F77FLAGS in the XL/POWER/Linux
configuration stanza.

For compatibility with other systems, the binary files (principally,
the intermediate files) created by the WPS programs should be written in
big-endian byte order. Adding the -qufmt=be compiler option to the FFLAGS and
F77FLAGS variables in the POWER/Linux stanza accomplishes this.

This PR fixes issue #129 .