### PR TITLE
Fix inconsistent kind types of arguments to MIN/MAX in module_map_utils

### DIFF
--- a/geogrid/src/module_map_utils.F
+++ b/geogrid/src/module_map_utils.F
@@ -805,7 +805,7 @@ MODULE map_utils
       ELSE
          gi2 = (proj%rebydx * scale_top)**2.
          lat = deg_per_rad * proj%hemi * ASIN((gi2-r2)/(gi2+r2))
-         arccos = ACOS(MIN(MAX(xx/SQRT(r2),-1.0),1.0))
+         arccos = ACOS(MIN(MAX(xx/SQRT(r2),-1.0_HIGH),1.0_HIGH))
          IF (yy .GT. 0) THEN
             lon = reflon + deg_per_rad * arccos
          ELSE


### PR DESCRIPTION
This PR fixes an inconsistency in the kind types of arguments to the MIN and MAX
intrinsics in module_map_utils.

The XL compiler identified calls to the MIN and MAX intrinsics in 
module_map_utils with inconsistent kind type parameters of the arguments:
```
    "module_map_utils.f90", line 819.44: 1513-041 (S) Arguments of the wrong type were specified for the INTRINSIC procedure "max".
    ** map_utils   === End of Compilation 1 ===
    1501-511  Compilation failed for file module_map_utils.f90.
```
This PR changes the kind type parameter of the literal arguments to MIN and MAX 
at line 808 of module_map_utils.F in the ijll_ps routine to HIGH.