### PR TITLE
Add configuration stanza for PGI compilers on Linux/POWER9

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -19,6 +19,27 @@ CFLAGS              =
 CPP                 = cpp -P -traditional
 CPPFLAGS            = -Uvector -DBYTESWAP -DLINUX -DIO_NETCDF -DIO_BINARY -DIO_GRIB1 -DBIT32 CONFIGURE_MPI
 ARFLAGS             =
+########################################################################################################################
+#ARCH   Linux ppc64le POWER Linux, PGI compiler # serial serial_NO_GRIB2 dmpar dmpar_NO_GRIB2
+#
+COMPRESSION_LIBS    = CONFIGURE_COMP_L
+COMPRESSION_INC     = CONFIGURE_COMP_I
+FDEFS               = CONFIGURE_FDEFS
+NCARG_LIBS          =
+NCARG_LIBS2         =
+FC                  = mpifort
+SFC                 = pgfortran
+CC                  = mpicc
+SCC                 = pgcc
+LD                  = $(FC)
+FFLAGS              = -Mfree -byteswapio
+F77FLAGS            = -Mfixed -byteswapio
+FNGFLAGS            = $(FFLAGS)
+LDFLAGS             =
+CFLAGS              =
+CPP                 = cpp -P -traditional
+CPPFLAGS            = -Uvector -D_UNDERSCORE -DBYTESWAP -DLINUX -DIO_NETCDF -DIO_BINARY -DIO_GRIB1 -DBIT32 CONFIGURE_MPI
+ARFLAGS             =
 
 ########################################################################################################################
 #ARCH   Linux ppc64 BG bglxf compiler with blxlc  # dmpar


### PR DESCRIPTION
This PR adds a new configuration stanza for building with the PGI compilers
on Linux/POWER9 systems.

This configuration stanza has been used to successfully build the WPS
on ORNL Summit using the PGI 19.9 compilers.