### PR TITLE
Fix plotfmt.ncl for use with Lambert Conformal projections

### DIFF
--- a/util/plotfmt.ncl
+++ b/util/plotfmt.ncl
@@ -164,6 +164,8 @@ begin
         res@mpLambertParallel1F = truelat1
         res@mpLambertParallel2F = truelat2
         res@mpLambertMeridianF = xlonc
+        res@pmTickMarkDisplayMode = "Always"
+        res@mpGridAndLimbOn = True
       end if
 
       if (iproj.eq.4) then        ;Gaussian
@@ -191,18 +193,22 @@ begin
       slab = wrf_wps_rddata_int(istatus,nx,ny)
 
       slab@_FillValue = -1e+30
-      slab!1 = "lon"
-      slab!0 = "lat"
-      slab&lon = lon
-      slab&lat = lat
+      if (iproj.ne.3) then ; NOT Lambert Conformal
+         slab!1 = "lon"
+         slab!0 = "lat"
+         slab&lon = lon
+         slab&lat = lat
+      end if
       slab@units = units
 
       slab@description = xlvl +"  "+ desc
 ;     printVarSummary(slab)
 
       map = gsn_csm_contour_map(wks,slab,res)
-      delete(lat)
-      delete(lon)
+      if (iproj.ne.3) then ; NOT Lambert Conformal
+         delete(lat)
+         delete(lon)
+      end if
       delete(slab)
 
       wrf_wps_rdhead_int(istatus,head_real,field,hdate, \


### PR DESCRIPTION
The util/plotfmt.ncl script did not work with Lambert Conformal (LC) projections.
```
>ncl util/plotfmt.ncl 'filename="FILE:2020-04-19_00"'

 Copyright (C) 1995-2019 - All Rights Reserved
 University Corporation for Atmospheric Research
 NCAR Command Language Version 6.6.2
 The use of this software is governed by a License Agreement.
 See http://www.ncl.ucar.edu/ for more details.
(0)	==================================================
(0)	VAR = PMSL__201300
(0)	hdate         = '2020-04-19_00:00:00'
(0)	units         = 'Pa'
(0)	desc          = 'Sea-level Pressure'
(0)	field         = 'PMSL'
(0)	map_source    = 'NCEP RAP Model          GRID 130'
(0)	version       = 5
(0)	xfcst         = 0
(0)	xlvl          = 201300
(0)	nx/ny         = 451/337
(0)	iproj         = 3
(0)	lat0/lon0     = 16.281/233.862
(0)	head_real(8)  = 13.545
(0)	head_real(9)  = 13.545
(0)	head_real(10) = 265
(0)	head_real(11) = 25
(0)	head_real(12) = 25
(0)	head_real(13) = 6371.23
fatal:Variable (lon) is undefined
fatal:["Execute.c":8637]:Execute: Error occurred at or near line 196 in file util/plotfmt.ncl
```

Here is line 196
```
    189       ; Read 2D data
    190
    191       slab = wrf_wps_rddata_int(istatus,nx,ny)
    192
    193       slab@_FillValue = -1e+30
    194       slab!1 = "lon"
    195       slab!0 = "lat"
    196       slab&lon = lon
    197       slab&lat = lat
    198       slab@units = units
```

For the LC projections, the fields `lat` and `lon` are not required, and so are never defined. The 
assignments using `lat` and `lon`, and the subsequent deallocation of those two fields are 
both removed from the run-time processing with `if` tests for the LC projection.

While providing a fix for this, Ming additionally added the lat lon lines on the LC plots. This is by 
adding two extra lines in the LC projection `if` block.

Only a single file is modified:
util/plotfmt.ncl

Demonstration that the scheme still behaves.

1. GFS plot of intermediate data (this used to work, and still does):
![Screen Shot 2020-05-08 at 10 48 35 AM](https://user-images.githubusercontent.com/12666234/81429784-8d5c4380-911b-11ea-8cd8-ca3418ede48b.png)

2. RAP/HRRR plot of intermediate data (this did not work before the fix):
![Screen Shot 2020-05-08 at 10 49 29 AM](https://user-images.githubusercontent.com/12666234/81429818-9e0cb980-911b-11ea-87f5-b192f9b06e85.png)

RELEASE NOTE: A small modification was made to the util/plotfmt.ncl script to allow processing the intermediate data from Lambert Conformal projections (such as from the RAP/HRRR suite). This is entirely diagnostic, and does not impact the gridded data sent into the WRF modeling system.
