### PR TITLE
Update "build_hdate.F" for 3-digit years

### DIFF
--- a/ungrib/src/build_hdate.F
+++ b/ungrib/src/build_hdate.F
@@ -23,19 +23,19 @@
 
       if (hlen.eq.19) then
          write(hdate,19) iyr, imo, idy, ihr, imi, isc
- 19      format(i4,'-',i2.2,'-',i2.2,'_',i2.2,':',i2.2,':',i2.2)
+ 19      format(i4.4,'-',i2.2,'-',i2.2,'_',i2.2,':',i2.2,':',i2.2)
 
       elseif (hlen.eq.16) then
          write(hdate,16) iyr, imo, idy, ihr, imi
- 16      format(i4,'-',i2.2,'-',i2.2,'_',i2.2,':',i2.2)
+ 16      format(i4.4,'-',i2.2,'-',i2.2,'_',i2.2,':',i2.2)
 
       elseif (hlen.eq.13) then
          write(hdate,13) iyr, imo, idy, ihr
- 13      format(i4,'-',i2.2,'-',i2.2,'_',i2.2)
+ 13      format(i4.4,'-',i2.2,'-',i2.2,'_',i2.2)
 
       elseif (hlen.eq.10) then
          write(hdate,10) iyr, imo, idy
- 10      format(i4,'-',i2.2,'-',i2.2)
+ 10      format(i4.4,'-',i2.2,'-',i2.2)
       endif
 
       return


### PR DESCRIPTION
I am doing some paleo-downscaling with WRF, and have to ungrib a set of files that contain data at 3-digit years (e.g. year 450). Ungrib.exe was unable to extract data from these files, as

hdate 450-01-01_00:00:00 > hsave 0000-00-00_00:00:00

was not evaluated as true in one of the internal loops.
This was apparently caused by a formatting error when hdate was created.

I simply turned the year format from 'i4' to 'i4.4' on lines 26,30,34 and 38; which forces a leading zero (just as in other formatted time units). I did the same in 'geth_newdate.F', too.	

hdate 0450-01-01_00:00:00 > hsave 0000-00-00_00:00:00

The above is now .true., so ungrib.exe works for 3-digit years as well.