### PR TITLE
Update "geth_newdate.F" for 3-digit years

### DIFF
--- a/ungrib/src/geth_newdate.F
+++ b/ungrib/src/geth_newdate.F
@@ -238,19 +238,19 @@
 
       if (nlen.ge.19) then
          write(ndate,19) yrnew, monew, dynew, hrnew, minew, scnew
- 19      format(I4,'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2,':',I2.2)
+ 19      format(I4.4,'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2,':',I2.2)
 
       else if (nlen.eq.16) then
          write(ndate,16) yrnew, monew, dynew, hrnew, minew
- 16      format(I4,'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2)
+ 16      format(I4.4,'-',I2.2,'-',I2.2,'_',I2.2,':',I2.2)
 
       else if (nlen.eq.13) then
          write(ndate,13) yrnew, monew, dynew, hrnew
- 13      format(I4,'-',I2.2,'-',I2.2,'_',I2.2)
+ 13      format(I4.4,'-',I2.2,'-',I2.2,'_',I2.2)
 
       else if (nlen.eq.10) then
          write(ndate,10) yrnew, monew, dynew
- 10      format(I4,'-',I2.2,'-',I2.2)
+ 10      format(I4.4,'-',I2.2,'-',I2.2)
 
       endif
 


### PR DESCRIPTION
I am doing some paleo-downscaling with WRF, and have to ungrib a set of files that contain data at 3-digit years (e.g. year 450). Ungrib.exe was unable to extract data from these files, as

hdate 450-01-01_00:00:00 > hsave 0000-00-00_00:00:00

was not evaluated as true in one of the internal loops.
This was apparently caused by a formatting error when hdate was created.

I simply turned the year format from 'I4' to 'I4.4' on lines 241,245,249 and 253; which forces a leading zero (just as in other formatted time units). I did the same in 'build_hdate.F', too.	

hdate 0450-01-01_00:00:00 > hsave 0000-00-00_00:00:00

The above is now .true., so ungrib.exe works for 3-digit years as well.