### PR TITLE
namelist.wps updates to newer case dates/domain to match updated default namelist.input

### DIFF
--- a/namelist.wps
+++ b/namelist.wps
@@ -1,8 +1,8 @@
 &share
  wrf_core = 'ARW',
  max_dom = 2,
- start_date = '2006-08-16_12:00:00','2006-08-16_12:00:00',
- end_date   = '2006-08-16_18:00:00','2006-08-16_12:00:00',
+ start_date = '2019-09-04_12:00:00','2019-09-04_12:00:00',
+ end_date   = '2019-09-06_00:00:00','2019-09-04_12:00:00',
  interval_seconds = 21600
  io_form_geogrid = 2,
 /
@@ -10,10 +10,10 @@
 &geogrid
  parent_id         =   1,   1,
  parent_grid_ratio =   1,   3,
- i_parent_start    =   1,  31,
- j_parent_start    =   1,  17,
- e_we              =  74, 112,
- e_sn              =  61,  97,
+ i_parent_start    =   1,  53,
+ j_parent_start    =   1,  25,
+ e_we              =  150, 220,
+ e_sn              =  130, 214,
  !
  !!!!!!!!!!!!!!!!!!!!!!!!!!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ! The default datasets used to produce the MAXSNOALB and ALBEDO12M
@@ -28,14 +28,14 @@
  !!!!!!!!!!!!!!!!!!!!!!!!!!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!
  !
  geog_data_res = 'default','default',
- dx = 30000,
- dy = 30000,
+ dx = 15000,
+ dy = 15000,
  map_proj = 'lambert',
- ref_lat   =  34.83,
- ref_lon   = -81.03,
+ ref_lat   =  33.00,
+ ref_lon   = -79.00,
  truelat1  =  30.0,
  truelat2  =  60.0,
- stand_lon = -98.0,
+ stand_lon = -79.0,
  geog_data_path = '/glade/work/wrfhelp/WPS_GEOG/'
 /
 


### PR DESCRIPTION
Many settings for the default case in namelist.input were outdated or didn't follow current recommendations. A wrf-model PR ([#1306](https://github.com/wrf-model/WRF/pull/1306)) was submitted to update the namelist. To ensure consistency, updates are also made to namelist.wps to match those in namelist.input. Case dates, domain size, position, grid spacing, and latitude/longitude are modified. A note at the top of namelist.wps was added to inform users of the option to add comments. The new case (2019 Hurricane Dorian) was tested to ensure the outcome looks reasonable.