### PR TITLE
build: fix the gomp linking for gfortran with openmp and mpi

### DIFF
--- a/configure
+++ b/configure
@@ -431,3 +431,8 @@ EOF
 
   fi
 fi
+
+# Fix the gomp linking for openmp and mpi
+if [ $FC = "gfortran" -a $os = "Linux" -a $mach = "x86_64" ]; then
+    sed -i 's/-lnetcdff -lnetcdf/-lnetcdff -lnetcdf -lgomp/g' configure.wps
+fi


### PR DESCRIPTION
Hi,

If we chose options(ie. 1~4)  of `Linux x86_64, gfortran` at `./configure` in WPS while we had compiled WRF use openmp or mpi or both, it need link gomp library. So I added a simple replacement of WRF_LIB for this situation. This should have no effect on compiling WRF in serial mode.

Thanks.