### PR TITLE
Fix default input data resolution for gwd field ol3ss

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -932,7 +932,7 @@ name = OL3SS
         rel_path = 30m:orogwd3_30m/ol3ss/
         rel_path = 1deg:orogwd3_1deg/ol3ss/
         rel_path = 2deg:orogwd3_2deg/ol3ss/
-        rel_path = default:orogwd3_2.5m/ol3ss/
+        rel_path = default:orogwd3_10m/ol3ss/
 ===============================
 name = OL4SS
         priority = 1


### PR DESCRIPTION
The previous resolution for default input data is 2.5 minutes for field OL3SS, which is wrong. The correct default resolution for this field should 10 minutes. This PR corrects this.