### PR TITLE
Updated namelist.wps for consistency with updates to namelist.input

### DIFF
--- a/namelist.wps
+++ b/namelist.wps
@@ -3,8 +3,7 @@
  max_dom = 2,
  start_date = '2019-09-04_12:00:00','2019-09-04_12:00:00',
  end_date   = '2019-09-06_00:00:00','2019-09-04_12:00:00',
- interval_seconds = 21600
- io_form_geogrid = 2,
+ interval_seconds = 10800
 /
 
 &geogrid
@@ -14,19 +13,6 @@
  j_parent_start    =   1,  25,
  e_we              =  150, 220,
  e_sn              =  130, 214,
- !
- !!!!!!!!!!!!!!!!!!!!!!!!!!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!
- ! The default datasets used to produce the MAXSNOALB and ALBEDO12M
- ! fields have changed in WPS v4.0. These fields are now interpolated
- ! from MODIS-based datasets.
- !
- ! To match the output given by the default namelist.wps in WPS v3.9.1,
- ! the following setting for geog_data_res may be used:
- !
- ! geog_data_res = 'maxsnowalb_ncep+albedo_ncep+default', 'maxsnowalb_ncep+albedo_ncep+default', 
- !
- !!!!!!!!!!!!!!!!!!!!!!!!!!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!!!!!
- !
  geog_data_res = 'default','default',
  dx = 15000,
  dy = 15000,
@@ -46,5 +32,4 @@
 
 &metgrid
  fg_name = 'FILE'
- io_form_metgrid = 2, 
 /


### PR DESCRIPTION
Updated namelist.wps for consistency with updates to namelist.input (https://github.com/wrf-model/WRF/pull/1513), as well as minor improvements to decrease user confusion.

- Set interval_seconds to 10800 - namelists are set up specifically for GFS data, which most types are available every three hours.
- Removed io_form_geogrid and io_form_metgrid variables, as currently we only recommend setting these to 2 (default)
- Removed comment regarding using V3.9 settings for geog_data_res (outdated)
