### PR TITLE
Update 'compile' to V4.3.1

### DIFF
--- a/compile
+++ b/compile
@@ -112,7 +112,7 @@ endif
 # Print out WPS version, system info, and compiler/version
 echo "============================================================================================== "
   echo " "
-  echo Version 4.3
+  echo Version 4.3.1
   echo " "
   uname -a
   echo " "

--- a/compile
+++ b/compile
@@ -112,7 +112,7 @@ endif
 # Print out WPS version, system info, and compiler/version
 echo "============================================================================================== "
   echo " "
-  echo Version 4.2
+  echo Version 4.3
   echo " "
   uname -a
   echo " "


### PR DESCRIPTION
Prior to the V4.3 code release, the "compile" script version was not updated and it still printed "Version 4.2." I've updated it to "Version 4.3.1" so it will be correct for the V4.3.1 bug release.