### PR TITLE
Fix several incorrect argument ranks in calls to WRF I/O API routines

### DIFF
--- a/geogrid/src/output_module.F
+++ b/geogrid/src/output_module.F
@@ -1429,21 +1429,21 @@ module output_module
 #ifdef IO_BINARY
       if (io_form_output == BINARY) then
          call ext_int_put_dom_ti_integer(handle, trim(var_name), &
-                                         var_value, &
+                                         (/ var_value /), &
                                          1, istatus)
       end if
 #endif
 #ifdef IO_NETCDF
       if (io_form_output == NETCDF) then
          call ext_ncd_put_dom_ti_integer(handle, trim(var_name), &
-                                         var_value, &
+                                         (/ var_value /), &
                                          1, istatus)
       end if
 #endif
 #ifdef IO_GRIB1
       if (io_form_output == GRIB1) then
          call ext_gr1_put_dom_ti_integer(handle, trim(var_name), &
-                                         var_value, &
+                                         (/ var_value /), &
                                          1, istatus)
       end if
 #endif
@@ -1516,21 +1516,21 @@ module output_module
 #ifdef IO_BINARY
       if (io_form_output == BINARY) then
          call ext_int_put_dom_ti_real(handle, trim(var_name), &
-                                         var_value, &
+                                         (/ var_value /), &
                                          1, istatus)
       end if
 #endif
 #ifdef IO_NETCDF
       if (io_form_output == NETCDF) then
          call ext_ncd_put_dom_ti_real(handle, trim(var_name), &
-                                         var_value, &
+                                         (/ var_value /), &
                                          1, istatus)
       end if
 #endif
 #ifdef IO_GRIB1
       if (io_form_output == GRIB1) then
          call ext_gr1_put_dom_ti_real(handle, trim(var_name), &
-                                         var_value, &
+                                         (/ var_value /), &
                                          1, istatus)
       end if
 #endif

--- a/metgrid/src/input_module.F
+++ b/metgrid/src/input_module.F
@@ -633,25 +633,26 @@ module input_module
 
       ! Local variables
       integer :: istatus, outcount
+      integer, dimension(1) :: var_value_arr
 
 #ifdef IO_BINARY
       if (io_form_input == BINARY) then
          call ext_int_get_dom_ti_integer(handle, trim(var_name), &
-                                         var_value, &
+                                         var_value_arr, &
                                          1, outcount, istatus)
       end if
 #endif
 #ifdef IO_NETCDF
       if (io_form_input == NETCDF) then
          call ext_ncd_get_dom_ti_integer(handle, trim(var_name), &
-                                         var_value, &
+                                         var_value_arr, &
                                          1, outcount, istatus)
       end if
 #endif
 #ifdef IO_GRIB1
       if (io_form_input == GRIB1) then
          call ext_gr1_get_dom_ti_integer(handle, trim(var_name), &
-                                         var_value, &
+                                         var_value_arr, &
                                          1, outcount, istatus)
       end if
 #endif
@@ -661,6 +662,8 @@ module input_module
       else
          call mprintf((istatus /= 0),ERROR,'Error while reading domain time-independent attribute.')
       end if
+
+      var_value = var_value_arr(1)
 
    end subroutine ext_get_dom_ti_integer_scalar
 
@@ -724,30 +727,33 @@ module input_module
 
       ! Local variables
       integer :: istatus, outcount
+      real, dimension(1) :: var_value_arr
 
 #ifdef IO_BINARY
       if (io_form_input == BINARY) then
          call ext_int_get_dom_ti_real(handle, trim(var_name), &
-                                         var_value, &
+                                         var_value_arr, &
                                          1, outcount, istatus)
       end if
 #endif
 #ifdef IO_NETCDF
       if (io_form_input == NETCDF) then
          call ext_ncd_get_dom_ti_real(handle, trim(var_name), &
-                                         var_value, &
+                                         var_value_arr, &
                                          1, outcount, istatus)
       end if
 #endif
 #ifdef IO_GRIB1
       if (io_form_input == GRIB1) then
          call ext_gr1_get_dom_ti_real(handle, trim(var_name), &
-                                         var_value, &
+                                         var_value_arr, &
                                          1, outcount, istatus)
       end if
 #endif
 
       call mprintf((istatus /= 0),ERROR,'Error while reading domain time-independent attribute.')
+
+      var_value = var_value_arr(1)
 
    end subroutine ext_get_dom_ti_real_scalar
 


### PR DESCRIPTION
This PR corrects the actual argument rank in several calls to WRF I/O API
routines for reading and writing domain time-independent attributes.