### PR TITLE
Fix builds with newer GNU compilers

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -159,6 +159,7 @@ CC                  = CONFIGURE_CC
 LD                  = $(FC)
 FFLAGS              = -ffree-form -O -fconvert=big-endian -frecord-marker=4
 F77FLAGS            = -ffixed-form -O -fconvert=big-endian -frecord-marker=4
+FCCOMPAT            = CONFIGURE_COMPAT_FLAGS
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
@@ -182,6 +183,7 @@ CC                  = CONFIGURE_CC
 LD                  = $(FC)
 FFLAGS              = -ffree-form -O -fconvert=big-endian -frecord-marker=4
 F77FLAGS            = -ffixed-form -O -fconvert=big-endian -frecord-marker=4
+FCCOMPAT            = CONFIGURE_COMPAT_FLAGS
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
@@ -452,6 +454,7 @@ CC                  = CONFIGURE_CC
 LD                  = $(FC)
 FFLAGS              = -ffree-form -O -fconvert=big-endian -frecord-marker=4
 F77FLAGS            = -ffixed-form -O -fconvert=big-endian -frecord-marker=4
+FCCOMPAT            = CONFIGURE_COMPAT_FLAGS
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
@@ -477,6 +480,7 @@ CC                  = CONFIGURE_CC
 LD                  = $(FC)
 FFLAGS              = -ffree-form -O -fconvert=big-endian -frecord-marker=4
 F77FLAGS            = -ffixed-form -O -fconvert=big-endian -frecord-marker=4
+FCCOMPAT            = CONFIGURE_COMPAT_FLAGS
 FCSUFFIX            =
 FNGFLAGS            = $(FFLAGS)
 # For a WRF OpenMP build, add the gomp library for WPS

--- a/arch/postamble
+++ b/arch/postamble
@@ -18,10 +18,10 @@ AR		=	ar ru
 
 .f.o:
 	$(RM) $@ $*.mod
-	$(FC) $(F77FLAGS) -c $< $(WRF_INCLUDE)
+	$(FC) $(F77FLAGS) $(FCCOMPAT) -c $< $(WRF_INCLUDE)
 
 .F.o:
 	$(RM) $@ $*.mod
 	$(CPP) $(CPPFLAGS) $(FDEFS) $(WRF_INCLUDE) $< > $*.f90
-	$(FC) $(FFLAGS) -c $*.f90 $(WRF_INCLUDE)
+	$(FC) $(FFLAGS) $(FCCOMPAT) -c $*.f90 $(WRF_INCLUDE)
 #	$(RM) $*.f90

--- a/configure
+++ b/configure
@@ -458,3 +458,40 @@ EOF
 
   fi
 fi
+
+
+#
+# Check for newer GNU Fortran compilers that require the use of the following:
+# -fallow-argument-mismatch
+#
+cat > gnu_flag_test.F90 << EOF
+program gnu_flag_test
+#ifdef __GNUC__
+#if __GNUC__ > 9
+call exit(1)   ! A GNU extension, but at this point we know this is a GNU compiler
+#endif
+#endif
+end program gnu_flag_test
+EOF
+
+# The above test program gives exit status 1 iff we are using the GNU Fortran
+# compiler with a major version greater than 9
+
+FC=`grep ^SFC configure.wps | cut -d"=" -f2-`
+FFLAGS=`grep ^FFLAGS configure.wps | cut -d"=" -f2-`
+$FC ${FFLAGS} gnu_flag_test.F90 -o gnu_flag_test > /dev/null 2>&1
+if [ -f ./gnu_flag_test ]; then
+   ./gnu_flag_test > /dev/null 2>&1
+   if [ $? -eq 1 ]; then
+      compat="-fallow-argument-mismatch"
+   fi
+   rm gnu_flag_test
+else
+   printf "*** Failed to compile the gnu_flag_test program!\n"
+   printf "    This may be because the selected build option does not work correctly.\n"
+fi
+rm gnu_flag_test.F90
+
+sed "s/CONFIGURE_COMPAT_FLAGS/${compat}/" configure.wps > configure.wps.tmp
+mv configure.wps.tmp configure.wps
+

--- a/ungrib/src/Makefile
+++ b/ungrib/src/Makefile
@@ -55,13 +55,13 @@ g2print.exe:		filelist.o gridinfo.o g2print.o
 g2print.o:		table.o gridinfo.o filelist.o module_datarray.o \
 				ngl/g2/gribmod.o ngl/g2/params.o g2print.F
 			$(CPP) $(CPPFLAGS) $*.F > $*.f90
-			$(FC) -c $(FFLAGS) $(FCSUFFIX) $*.f90 -I. -I./ngl/g2
+			$(FC) -c $(FFLAGS) $(FCSUFFIX) $(FCCOMPAT) $*.f90 -I. -I./ngl/g2
 #			$(RM) $*.f90
 
 rd_grib2.o:		ngl/g2/gribmod.o module_debug.o table.o gridinfo.o ngl/g2/params.o new_storage.o \
 				rd_grib2.F
 			$(CPP) $(CPPFLAGS) $*.F > $*.f90
-			$(FC) -c $(F77FLAGS) $(FCSUFFIX) $*.f90 -I. -I./ngl/g2
+			$(FC) -c $(F77FLAGS) $(FCSUFFIX) $(FCCOMPAT) $*.f90 -I. -I./ngl/g2
 #			$(RM) $*.f90
 
 datint.o:		misc_definitions_module.o module_debug.o gridinfo.o new_storage.o datint.F
@@ -88,7 +88,7 @@ read_namelist.o:	misc_definitions_module.o module_debug.o read_namelist.F
 
 .F.o:
 			$(CPP) $(CPPFLAGS) $(FDEFS) $< > $*.f90
-			$(FC) -c $(FFLAGS) $*.f90
+			$(FC) -c $(FFLAGS) $(FCCOMPAT) $*.f90
 #			$(RM) $*.f90
 
 .c.o:

--- a/ungrib/src/ngl/g2/Makefile
+++ b/ungrib/src/ngl/g2/Makefile
@@ -65,11 +65,11 @@ superclean:	clean
 
 .F.o:
 	$(CPP) $(FDEFS) $*.F > $*.f90
-	$(FC) -c $(F77FLAGS) $*.f90
+	$(FC) -c $(F77FLAGS) $(FCCOMPAT) $*.f90
 	/bin/rm -f $*.f90
 
 .f.o:
-	$(FC) -c $(F77FLAGS) $*.f
+	$(FC) -c $(F77FLAGS) $(FCCOMPAT) $*.f
 
 .c.o:
 	$(CC) -c $(CFLAGS) $(CFLAGS2) $<

--- a/ungrib/src/ngl/w3/Makefile
+++ b/ungrib/src/ngl/w3/Makefile
@@ -42,7 +42,7 @@ clean:
 
 .f.o:
 	$(RM) $*.o
-	$(FC) $(F77FLAGS) -c $< 
+	$(FC) $(F77FLAGS) $(FCCOMPAT) -c $<
 
 .c.o:
 	$(RM) $*.o


### PR DESCRIPTION
This PR addresses build failures when newer GNU compilers are used.

Newer GNU compilers (in particular, major versions later than 9) appear to
require the -fallow-argument-mismatch option in order to successfully compile
certain modules that make calls to Fortran 77 routines that operate on various
datatypes: for example, the MPI_Bcast call can broadcast various data types, and
without the Fortran 90+ module interface, there are no overloaded explicit
interfaces for supported argument types, leading newer GNU Fortran compiler
releases to generate errors about inconsistent/mismatched argument types.

The configure script now builds a test program that determines whether the
Fortran compiler being used is GNU Fortran with a major version later than 9,
and sets the FCCOMPAT variable to -fallow-argument-mismatch in the configure.wps
file if so (and sets FCCOMPAT to an empty string otherwise).

Since Make treats undefined variables as empty strings, the FCCOMPAT variable
only needs to be defined for configuration options where it will be needed,
i.e., configuration options that use the GNU Fortran compiler.

Other compiler could follow what has been done in this commit to define FCCOMPAT
as needed through the use of additional test programs (and through the addition
of FCCOMPAT to other configuration stanzas).