### PR TITLE
If internal GRIB2 libs will be compiled, don't show user NO_GRIB2 config options

### DIFF
--- a/arch/Config.pl
+++ b/arch/Config.pl
@@ -105,16 +105,16 @@ if ($sw_grib2_path eq "")
          }
        }
    }
+   @platforms = ('serial', 'serial_NO_GRIB2', 'dmpar', 'dmpar_NO_GRIB2');
 }
 else
 {
    $sw_jasperlib_path = '-L$(INTERNAL_GRIB2_PATH)/lib -ljasper -lpng -lz';
    $sw_jasperinc_path = '-I$(INTERNAL_GRIB2_PATH)/include';
+   @platforms = ('serial', 'dmpar');
 }
 
 $validresponse = 0 ;
-# added this from the WRF Config.pl by John M.
-@platforms = ('serial', 'serial_NO_GRIB2', 'dmpar', 'dmpar_NO_GRIB2');
 # Display the choices to the user and get selection
 until ($validresponse)
 {


### PR DESCRIPTION
This merge removes NO_GRIB2 configuration options when the user has
run the configure script with the --build-grib2-libs flag.

If the user has provided the configure script with the --build-grib2-libs
option, it seems safe enough to assume the ungrib program should be built with
GRIB2 support (using the internally provided copies of zlib, libpng, and
JasPer), so half of the configuration options presented to the user can be
eliminated -- specifically, the NO_GRIB2 options.