### PR TITLE
Modifying METGRID.TBL.ARW for WRF PR #1567

### DIFF
--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -907,6 +907,79 @@ name=I_WIF_DEC
         interp_option=four_pt+average_4pt
         flag_in_output=FLAG_QNIFA_CL
 ========================================
+name=QNBCA_JAN ; output_name=B_WIF_JAN
+========================================
+name=B_WIF_JAN
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_FEB ; output_name=B_WIF_FEB
+========================================
+name=B_WIF_FEB
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_MAR ; output_name=B_WIF_MAR
+========================================
+name=B_WIF_MAR
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_APR ; output_name=B_WIF_APR
+========================================
+name=B_WIF_APR
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_MAY ; output_name=B_WIF_MAY
+========================================
+name=B_WIF_MAY
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_JUN ; output_name=B_WIF_JUN
+========================================
+name=B_WIF_JUN
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_JUL ; output_name=B_WIF_JUL
+========================================
+name=B_WIF_JUL
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_AUG ; output_name=B_WIF_AUG
+========================================
+name=B_WIF_AUG
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_SEP ; output_name=B_WIF_SEP
+========================================
+name=B_WIF_SEP
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_OCT ; output_name=B_WIF_OCT
+========================================
+name=B_WIF_OCT
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_NOV ; output_name=B_WIF_NOV
+========================================
+name=B_WIF_NOV
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+========================================
+name=QNBCA_DEC ; output_name=B_WIF_DEC
+========================================
+name=B_WIF_DEC
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+        flag_in_output=FLAG_QNBCA_CL
+========================================
 name=P_WIF_JAN
         z_dim_name=num_wif_levels
         interp_option=four_pt+average_4pt
@@ -1021,6 +1094,11 @@ name=QNIFA
         interp_option=four_pt+average_4pt
         flag_in_output=FLAG_QNIFA
 ========================================
+name=QNBCA
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+        flag_in_output=FLAG_QNBCA
+========================================
 name=P_WIF
         z_dim_name=num_wif_levels
         interp_option=four_pt+average_4pt
@@ -1033,6 +1111,22 @@ name=QNWFA2D
 name=QNIFA2D
         interp_option=four_pt+average_4pt
         flag_in_output=FLAG_QNIFA2D
+========================================
+name=QNBCA2D
+        interp_option=four_pt+average_4pt
+        flag_in_output=FLAG_QNBCA2D
+========================================
+name=QNOCBB2D
+        interp_option=nearest_neighbor
+        masked=water
+        fill_missing=0.
+        flag_in_output=FLAG_QNOCBB2D
+========================================
+name=QNBCBB2D
+        interp_option=nearest_neighbor
+        masked=water
+        fill_missing=0.
+        flag_in_output=FLAG_QNBCBB2D
 ========================================
 # This entry is only used for MPAS data
 name=smois

--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -832,7 +832,7 @@ name=QNWFA_DEC ; output_name=W_WIF_DEC
 name=W_WIF_DEC 
         z_dim_name=num_wif_levels
         interp_option=four_pt+average_4pt
-        flag_in_output=FLAG_QNWFA
+        flag_in_output=FLAG_QNWFA_CL
 ========================================
 name=QNIFA_JAN ; output_name=I_WIF_JAN
 ========================================
@@ -905,7 +905,7 @@ name=QNIFA_DEC ; output_name=I_WIF_DEC
 name=I_WIF_DEC 
         z_dim_name=num_wif_levels
         interp_option=four_pt+average_4pt
-        flag_in_output=FLAG_QNIFA
+        flag_in_output=FLAG_QNIFA_CL
 ========================================
 name=P_WIF_JAN
         z_dim_name=num_wif_levels
@@ -1012,12 +1012,27 @@ name=HGTMAXW
         flag_in_output=FLAG_HGTMAXW
 ========================================
 name=QNWFA
-        z_dim_name=num_qnwfa_levels
+        z_dim_name=num_wif_levels
         interp_option=four_pt+average_4pt
+        flag_in_output=FLAG_QNWFA
 ========================================
 name=QNIFA
-        z_dim_name=num_qnwfa_levels
+        z_dim_name=num_wif_levels
         interp_option=four_pt+average_4pt
+        flag_in_output=FLAG_QNIFA
+========================================
+name=P_WIF
+        z_dim_name=num_wif_levels
+        interp_option=four_pt+average_4pt
+        flag_in_output=FLAG_P_WIF
+========================================
+name=QNWFA2D
+        interp_option=four_pt+average_4pt
+        flag_in_output=FLAG_QNWFA2D
+========================================
+name=QNIFA2D
+        interp_option=four_pt+average_4pt
+        flag_in_output=FLAG_QNIFA2D
 ========================================
 # This entry is only used for MPAS data
 name=smois


### PR DESCRIPTION
This PR complements WRF PR #1567 (https://github.com/wrf-model/WRF/pull/1567) and #1616 (https://github.com/wrf-model/WRF/pull/1616) in order to clean
the logic in dyn_em/module_initialize_real, enable more flexibility when pre-processing first guess aerosol fields (e.g., GEOS-5) for the Thompson Aerosol-Aware scheme (mp_physics=28), and handle processing of black carbon aerosol and biomass burning emissions.

Here is the text taken from WRF PR #1567:
Modifications have been made to the METGRID.TBL file to simplify the subsequent logic in the real program's dyn_em/module_initialize_real. Specifically, we: 
   * replace FLAG_QNWFA and FLAG_QNIFA with FLAG_QNWFA_CL and FLAG_QNIFA_CL, respectively, in the W_WIF_DEC and I_WIF_DEC entries, where “CL” stands for climatology; 
   * add FLAG_QNWFA and FLAG_QNIFA to the QNWFA and QNIFA entries, respectively, for the first guess aerosol arrays;
   * add entry P_WIF to give the user the option to interpolate the first guess aerosol using the native pressure levels of the host model;
   * use num_wif_levels for any z dimension associated with the aerosol field entries (climatology or first guess);
   * add surface aerosol emission arrays QNWFA2D and QNIFA2D to be processed.

Here is the text taken from WRF PR #1616
We add entries to METGRID.TBL to handle the black carbon aerosol category in addition to biomass burning emissions. Specifically, we:
   * add monthly climatology entries for black carbon aerosol (B_WIF_*) which generate FLAG_QNBCA_CL for processing in real
   * add first guess entry for black carbon aerosol (QNBCA) which generates FLAG_QNBCA for processing in real
   * add first guess entry for anthropogenic emission of black carbon aerosol (QNBCA2D) which generates FLAG_QNBCA2D
   * add first guess entries for biomass burning emissions of organic carbon (QNOCBB2D) and black carbon (QNBCBB2D) which generate FLAG_QNOCBB2D and FLAG_QNBCBB2D, respectively

Note that the new .dat file for monthly GOCART climatology is hosted on Google Drive: https://drive.google.com/file/d/1BYflyu65kP5giRYbTzKo6y4iSnTfb1Fw/view?usp=sharing