### PR TITLE
Added bathymetry section to GEOGRID.TBL.ARW

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -957,3 +957,12 @@ name = OL4SS
         rel_path = 2deg:orogwd3_2deg/ol4ss/
         rel_path = default:orogwd3_10m/ol4ss/
 ===============================
+name = BATHYMETRY
+        priority = 1
+        dest_type = continuous
+        optional=yes
+        fill_missing=999.
+        interp_option = default:average_gcell(1.0)+search(5)
+        rel_path =  default:topobath_30s/
+        flag_in_output=FLAG_BATHYMETRY
+===============================


### PR DESCRIPTION
A new option to incorporate the shallow water drag module into the revised M-O surface layer scheme for over-water roughness calculation was added to the WRF model code (see [PR#1543](https://github.com/wrf-model/WRF/pull/1543)). To use this new data, it was necessary to add a section to the GEOGRID.TBL.ARW file. 