### PR TITLE
Fixing bug in subgrid interpolation

### DIFF
--- a/geogrid/src/proc_point_module.F
+++ b/geogrid/src/proc_point_module.F
@@ -248,8 +248,8 @@ module proc_point_module
          call xytoll(real(min_i), real(min_j), lat_corner, lon_corner, M)
          call select_domain(current_domain)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx-1.0) * sr_x + 1.0
-         ry = (ry-1.0) * sr_y + 1.0
+         rx = (rx-0.5) * sr_x + 0.5
+         ry = (ry-0.5) * sr_y + 0.5
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. real(start_y) <= ry .and. ry <= real(end_y)) then
             where_maps_to(min_i,min_j,1) = nint(rx)
             where_maps_to(min_i,min_j,2) = nint(ry)
@@ -265,8 +265,8 @@ module proc_point_module
          call xytoll(real(min_i), real(max_j), lat_corner, lon_corner, M)
          call select_domain(current_domain)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx-1.0) * sr_x + 1.0
-         ry = (ry-1.0) * sr_y + 1.0
+         rx = (rx-0.5) * sr_x + 0.5
+         ry = (ry-0.5) * sr_y + 0.5
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. real(start_y) <= ry .and. ry <= real(end_y)) then
             where_maps_to(min_i,max_j,1) = nint(rx)
             where_maps_to(min_i,max_j,2) = nint(ry)
@@ -282,8 +282,8 @@ module proc_point_module
          call xytoll(real(max_i), real(max_j), lat_corner, lon_corner, M)
          call select_domain(current_domain)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx-1.0) * sr_x + 1.0
-         ry = (ry-1.0) * sr_y + 1.0
+         rx = (rx-0.5) * sr_x + 0.5
+         ry = (ry-0.5) * sr_y + 0.5
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. real(start_y) <= ry .and. ry <= real(end_y)) then
             where_maps_to(max_i,max_j,1) = nint(rx)
             where_maps_to(max_i,max_j,2) = nint(ry)
@@ -299,8 +299,8 @@ module proc_point_module
          call xytoll(real(max_i), real(min_j), lat_corner, lon_corner, M)
          call select_domain(current_domain) 
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx-1.0) * sr_x + 1.0
-         ry = (ry-1.0) * sr_y + 1.0
+         rx = (rx-0.5) * sr_x + 0.5
+         ry = (ry-0.5) * sr_y + 0.5
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. real(start_y) <= ry .and. ry <= real(end_y)) then
             where_maps_to(max_i,min_j,1) = nint(rx)
             where_maps_to(max_i,min_j,2) = nint(ry)
@@ -583,8 +583,8 @@ module proc_point_module
          call xytoll(real(min_i), real(min_j), lat_corner, lon_corner, M)
          call select_domain(current_domain)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx-1.0) * sr_x + 1.0
-         ry = (ry-1.0) * sr_y + 1.0
+         rx = (rx-0.5) * sr_x + 0.5
+         ry = (ry-0.5) * sr_y + 0.5
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. real(start_y) <= ry .and. ry <= real(end_y)) then
             where_maps_to(min_i,min_j,1) = nint(rx)
             where_maps_to(min_i,min_j,2) = nint(ry)
@@ -600,8 +600,8 @@ module proc_point_module
          call xytoll(real(min_i), real(max_j), lat_corner, lon_corner, M)
          call select_domain(current_domain)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx-1.0) * sr_x + 1.0
-         ry = (ry-1.0) * sr_y + 1.0
+         rx = (rx-0.5) * sr_x + 0.5
+         ry = (ry-0.5) * sr_y + 0.5
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. real(start_y) <= ry .and. ry <= real(end_y)) then
             where_maps_to(min_i,max_j,1) = nint(rx)
             where_maps_to(min_i,max_j,2) = nint(ry)
@@ -617,8 +617,8 @@ module proc_point_module
          call xytoll(real(max_i), real(max_j), lat_corner, lon_corner, M)
          call select_domain(current_domain)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx-1.0) * sr_x + 1.0
-         ry = (ry-1.0) * sr_y + 1.0
+         rx = (rx-0.5) * sr_x + 0.5
+         ry = (ry-0.5) * sr_y + 0.5
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. real(start_y) <= ry .and. ry <= real(end_y)) then
             where_maps_to(max_i,max_j,1) = nint(rx)
             where_maps_to(max_i,max_j,2) = nint(ry)
@@ -634,8 +634,8 @@ module proc_point_module
          call xytoll(real(max_i), real(min_j), lat_corner, lon_corner, M)
          call select_domain(current_domain) 
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx-1.0) * sr_x + 1.0
-         ry = (ry-1.0) * sr_y + 1.0
+         rx = (rx-0.5) * sr_x + 0.5
+         ry = (ry-0.5) * sr_y + 0.5
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. real(start_y) <= ry .and. ry <= real(end_y)) then
             where_maps_to(max_i,min_j,1) = nint(rx)
             where_maps_to(max_i,min_j,2) = nint(ry)

--- a/geogrid/src/process_tile_module.F
+++ b/geogrid/src/process_tile_module.F
@@ -1715,7 +1715,7 @@ module process_tile_module
 
       do i=start_mem_i, end_mem_i
          do j=start_mem_j, end_mem_j
-            call xytoll(real(i-1)/rx+1.0, real(j-1)/ry+1.0, &
+            call xytoll(real(i-0.5)/rx+0.5, real(j-0.5)/ry+0.5, &
                         xlat_arr(i,j), xlon_arr(i,j), stagger, comp_ll=comp_ll)
          end do
       end do

--- a/metgrid/src/process_domain_module.F
+++ b/metgrid/src/process_domain_module.F
@@ -3445,8 +3445,8 @@ integer, parameter :: BDR_WIDTH = 3
          call xytoll(real(min_i), real(min_j), lat_corner, lon_corner, istagger)
          call select_domain(1)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx - 1.0)*sr_x + 1.0
-         ry = (ry - 1.0)*sr_y + 1.0
+         rx = (rx - 0.5)*sr_x + 0.5
+         ry = (ry - 0.5)*sr_y + 0.5
          call select_domain(orig_selected_domain)
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. &
              real(start_y) <= ry .and. ry <= real(end_y)) then
@@ -3464,8 +3464,8 @@ integer, parameter :: BDR_WIDTH = 3
          call xytoll(real(min_i), real(max_j), lat_corner, lon_corner, istagger)
          call select_domain(1)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx - 1.0)*sr_x + 1.0
-         ry = (ry - 1.0)*sr_y + 1.0
+         rx = (rx - 0.5)*sr_x + 0.5
+         ry = (ry - 0.5)*sr_y + 0.5
          call select_domain(orig_selected_domain)
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. &
              real(start_y) <= ry .and. ry <= real(end_y)) then
@@ -3483,8 +3483,8 @@ integer, parameter :: BDR_WIDTH = 3
          call xytoll(real(max_i), real(max_j), lat_corner, lon_corner, istagger)
          call select_domain(1)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx - 1.0)*sr_x + 1.0
-         ry = (ry - 1.0)*sr_y + 1.0
+         rx = (rx - 0.5)*sr_x + 0.5
+         ry = (ry - 0.5)*sr_y + 0.5
          call select_domain(orig_selected_domain)
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. &
              real(start_y) <= ry .and. ry <= real(end_y)) then
@@ -3502,8 +3502,8 @@ integer, parameter :: BDR_WIDTH = 3
          call xytoll(real(max_i), real(min_j), lat_corner, lon_corner, istagger)
          call select_domain(1)
          call lltoxy(lat_corner, lon_corner, rx, ry, istagger)
-         rx = (rx - 1.0)*sr_x + 1.0
-         ry = (ry - 1.0)*sr_y + 1.0
+         rx = (rx - 0.5)*sr_x + 0.5
+         ry = (ry - 0.5)*sr_y + 0.5
          call select_domain(orig_selected_domain)
          if (real(start_x) <= rx .and. rx <= real(end_x) .and. &
              real(start_y) <= ry .and. ry <= real(end_y)) then


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: subgrid, interpolation, indexing, fire

SOURCE: Angel Farguell and Adam Kochanski (San Jose State University), Jan Mandel (University of Colorado Denver)

DESCRIPTION OF CHANGES:
**Problem:**
When processing data into WPS release-v4.3.1 using a geogrid option `subgrid=yes`, the resulting variables inside WPS are generated with shifting errors of about 0.375·*dx* and 0.375·*dy* to x and y direction respectively, where *dx* and *dy* are the atmospheric grid resolutions. The problem is a combination of the next two problems:
- Subroutine get_lat_lon_fields from file geogrid/src/process_tile_module.F and subroutine process_continuous_block from metgrid/src/process_domain_module.F: Translates subgrid indexes [*i<sub>s</sub>*,*j<sub>s</sub>*] to atmosphere indexes [(*i<sub>s</sub>*-1)/*sr_x*+1.0,(*j<sub>s</sub>*-1)/*sr_y*+1.0], where *sr_x* and *sr_y* are the subgrid ratios.
- Subroutines process_categorical_block and process_continuous_block from file geogrid/src/proc_point_module.F: Translates atmosphere indexes [*i*,*j*] to subgrid indexes [(*i*-1)·*sr_x*+1.0,(*j*-1)·*sr_y*+1.0], where *sr_x* and *sr_y* are the subgrid ratios.

**Solution:**
Replace the above expressions with the correct indexing:
- Subroutine get_lat_lon_fields from file geogrid/src/process_tile_module.F: Replace expression [(*i<sub>s</sub>*-1)/*sr_x*+1.0,(*j<sub>s</sub>*-1)/*sr_y*+1.0] by [(*i<sub>s</sub>*-0.5)/*sr_x*+0.5,(*j<sub>s</sub>*-0.5)/*sr_y*+0.5], where *sr_x* and *sr_y* are the subgrid ratios.
- Subroutines process_categorical_block and process_continuous_block from file geogrid/src/proc_point_module.F and subroutine process_continuous_block from metgrid/src/process_domain_module.F: Replace expression [(*i*-1)·*sr_x*+1.0,(*j*-1)·*sr_y*+1.0] by [(*i*-0.5)·*sr_x*+0.5,(*j*-0.5)·*sr_y*+0.5], where *sr_x* and *sr_y* are the subgrid ratios.

LIST OF MODIFIED FILES:
M       geogrid/src/proc_point_module.F
M       geogrid/src/process_tile_module.F
M       metgrid/src/process_domain_module.F

TESTS CONDUCTED:
- [x] **Indexes case:** create two incremental index arrays (one for each horizontal direction). Feed them into WPS using 1 domain, subgrid_ratio_x=subgrid_ratio_y=4, and creating 2 new variables for each array (one with and without option `subgrid=yes`).
- [x] **Real case:** Feed high-resolution elevation and fuel categories from [LANDFIRE](https://landfire.cr.usgs.gov) website into WPS in the 3rd domain using option `subgrid=yes` and subgrid_ratio_x=subgrid_ratio_y=0, 0, 20.

RELEASE NOTE:
Processing subgrid variables into WPS release-v4.3.1 creates shift errors of about 0.375·*dx* and 0.375·*dy*, where *dx* and *dy* are the atmospheric grid resolutions. 

The image shows the first 10x10 grid points in each 2D dimension from the WPS geo_em.d01.nc file after running the indexes case. The right-hand-side figure shows how WPS release v4.3.1 creates shift errors and how they are corrected on the left-hand-side figure after modifying the code.

![pr_indexes](https://user-images.githubusercontent.com/9255649/155754077-1d7c0a00-2f21-487e-8bfe-df8364af59db.png)

The illustration is a transparent overlay of LANDFIRE's fuel categories original data (30m resolution) on the background layer of WPS output. The right-hand-side figure shows how WPS release v4.3.1 creates shift errors and how they are corrected on the left-hand-side figure after modifying the code.

![pr_real](https://user-images.githubusercontent.com/9255649/155754114-ed2ccd9d-1e42-4a17-8cab-7d54d88f2c7b.png)