### PR TITLE
Geogrid Subgrid Processing

### DIFF
--- a/geogrid/src/output_module.F
+++ b/geogrid/src/output_module.F
@@ -459,6 +459,7 @@ module output_module
       character (len=128) :: memorder, units, description
       character (len=128), dimension(3) :: dimnames 
       integer :: sr_x, sr_y
+      logical :: is_subgrid_var, sub_status
   
       !
       ! First find out how many fields there are
@@ -474,7 +475,8 @@ module output_module
                                         min_category, max_category, &
                                         istagger, memorder, dimnames, &
                                         units, description, sr_x, sr_y, &
-                                        derived_from, ifieldstatus)
+                                        is_subgrid_var, derived_from, ifieldstatus)
+         sub_status = (.not. is_subgrid_var .or. (sr_x > 0 .or. sr_y > 0))
 #ifdef _GEOGRID
          if (len_trim(derived_from) > 0) then
             call get_source_opt_status(trim(derived_from), 0, optstatus)
@@ -483,7 +485,7 @@ module output_module
          end if
 #endif
    
-         if (ifieldstatus == 0 .and. optstatus == 0) then
+         if (ifieldstatus == 0 .and. optstatus == 0 .and. sub_status) then
             nfields = nfields + 1
          end if
       end do
@@ -932,7 +934,8 @@ module output_module
                                       min_category, max_category, &
                                       istagger, memorder, dimnames, &
                                       units, description, sr_x, sr_y, &
-                                      derived_from, ifieldstatus)
+                                      is_subgrid_var, derived_from, ifieldstatus)
+         sub_status = (.not. is_subgrid_var .or. (sr_x > 0 .or. sr_y > 0))
 #ifdef _GEOGRID
          if (len_trim(derived_from) > 0) then
             call get_source_opt_status(trim(derived_from), 0, optstatus)
@@ -942,7 +945,7 @@ module output_module
 #endif
 
    
-         if (ifieldstatus == 0 .and. optstatus == 0) then !{
+         if (ifieldstatus == 0 .and. optstatus == 0 .and. sub_status) then !{
      
             fields(nfields)%ndims = ndims
             fields(nfields)%fieldname = fieldname

--- a/geogrid/src/process_tile_module.F
+++ b/geogrid/src/process_tile_module.F
@@ -67,7 +67,8 @@ module process_tile_module
                                        sina_array, cosa_array
       real, pointer, dimension(:,:) :: xlat_ptr, xlon_ptr, mapfac_ptr_x, mapfac_ptr_y, landmask, dominant_field
       real, pointer, dimension(:,:,:) :: field, slp_field
-      logical :: is_water_mask, only_save_dominant, halt_on_missing
+      logical :: is_water_mask, only_save_dominant, halt_on_missing, &
+                 is_subgrid_var, sub_status
       character (len=19) :: datestr
       character (len=128) :: fieldname, gradname, domname, landmask_name
       character (len=256) :: temp_string
@@ -747,17 +748,17 @@ module process_tile_module
             temp_string(1:128) = fieldname
 
             call get_source_opt_status(fieldname, 0, opt_status)
-      
+            call get_output_stagger(fieldname, istagger, istatus)
+            dimnames(:) = 'null'
+            call get_subgrid_dim_name(which_domain, fieldname, dimnames, &
+                                      sub_x, sub_y, is_subgrid_var, istatus)
+            sub_status = (.not. is_subgrid_var .or. (sub_x > 0 .or. sub_y > 0))
+             
             ! If this field is still to be processed
-            if (.not. hash_search(processed_fieldnames, temp_string) .and. opt_status == 0) then
+            if (.not. hash_search(processed_fieldnames, temp_string) .and. opt_status == 0 .and. sub_status) then
      
                call hash_insert(processed_fieldnames, temp_string)
                call mprintf(.true.,STDOUT,'  Processing %s', s1=trim(fieldname))
-       
-               call get_output_stagger(fieldname, istagger, istatus)
-               dimnames(:) = 'null'
-               call get_subgrid_dim_name(which_domain, fieldname, dimnames, &
-                                         sub_x, sub_y, istatus)
        
                if (istagger == M .or. (sub_x > 1) .or. (sub_y > 1)) then
                   sm1 = start_mem_i

--- a/geogrid/src/source_data_module.F
+++ b/geogrid/src/source_data_module.F
@@ -1349,7 +1349,7 @@ module source_data_module
    recursive subroutine get_next_output_fieldname(nest_num, field_name, ndims, &
                                             min_cat, max_cat, istagger, memorder, &
                                             dimnames, units, description, sr_x, sr_y, &
-                                            derived_from, istatus)
+                                            is_subgrid_var, derived_from, istatus)
 
       use gridinfo_module
  
@@ -1361,6 +1361,7 @@ module source_data_module
       integer, intent(in) :: nest_num
       integer, intent(out) :: istatus, ndims, istagger, min_cat, max_cat
       integer, intent(out) :: sr_x, sr_y
+      logical, intent(out) :: is_subgrid_var
       character (len=128), intent(out) :: memorder, field_name, units, description, derived_from
       character (len=128), dimension(3), intent(out) :: dimnames
   
@@ -1389,7 +1390,7 @@ module source_data_module
                call get_next_output_fieldname(nest_num, field_name, ndims, &
                                               min_cat, max_cat, istagger, &
                                               memorder, dimnames, units, description, &
-                                              sr_x, sr_y, derived_from, istatus)
+                                              sr_x, sr_y, is_subgrid_var, derived_from, istatus)
                return
             else
                ndims = 2
@@ -1432,7 +1433,7 @@ module source_data_module
                   memorder = '   ' 
                   dimnames(3) = ' '
                end if
-               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, istatus)
+               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, is_subgrid_var, istatus)
                call get_source_units(field_name, 1, units, istatus)
                if (istatus /= 0) units = '-'
                call get_source_descr(field_name, 1, description, istatus)
@@ -1445,7 +1446,7 @@ module source_data_module
             call get_next_output_fieldname(nest_num, field_name, ndims, &
                                            min_cat, max_cat, istagger, &
                                            memorder, dimnames, units, description, &
-                                           sr_x, sr_y, derived_from, istatus)
+                                           sr_x, sr_y, is_subgrid_var, derived_from, istatus)
             return
          end if
   
@@ -1464,7 +1465,7 @@ module source_data_module
                call get_next_output_fieldname(nest_num, field_name, ndims, &
                                               min_cat, max_cat, istagger, &
                                               memorder, dimnames, units, description, &
-                                              sr_x, sr_y, derived_from, istatus)
+                                              sr_x, sr_y, is_subgrid_var, derived_from, istatus)
                return
      
             ! Return the fractional field
@@ -1509,7 +1510,7 @@ module source_data_module
                   memorder = '   ' 
                   dimnames(3) = ' '
                end if
-               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, istatus)
+               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, is_subgrid_var, istatus)
                call get_source_units(field_name, 1, units, istatus)
                if (istatus /= 0) units = '-'
                call get_source_descr(field_name, 1, description, istatus)
@@ -1525,7 +1526,7 @@ module source_data_module
             call get_next_output_fieldname(nest_num, field_name, ndims, &
                                            min_cat, max_cat, istagger, &
                                            memorder, dimnames, units, description, &
-                                           sr_x, sr_y, derived_from, istatus)
+                                           sr_x, sr_y, is_subgrid_var, derived_from, istatus)
             return
          end if
   
@@ -1564,7 +1565,7 @@ module source_data_module
                dimnames(3) = ' ' 
                memorder = 'XY ' 
 
-               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, istatus)
+               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, is_subgrid_var, istatus)
                field_name = domcat_name
                units = 'category'
                description = 'Dominant category'
@@ -1582,7 +1583,7 @@ module source_data_module
                call get_next_output_fieldname(nest_num, field_name, ndims, &
                                               min_cat, max_cat, istagger, &
                                               memorder, dimnames, units, description, &
-                                              sr_x, sr_y, derived_from, istatus)
+                                              sr_x, sr_y, is_subgrid_var, derived_from, istatus)
               return
             end if 
          else
@@ -1648,7 +1649,7 @@ module source_data_module
 !               field_name = dfdx_name
 !               units = '-'
 
-               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, istatus)
+               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, is_subgrid_var, istatus)
 ! Correct location of the two lines of code is below (see also dfdy)
                field_name = dfdx_name
                units = '-'
@@ -1668,7 +1669,7 @@ module source_data_module
                call get_next_output_fieldname(nest_num, field_name, ndims, &
                                               min_cat, max_cat, istagger, &
                                               memorder, dimnames, units, description, &
-                                              sr_x, sr_y, derived_from, istatus)
+                                              sr_x, sr_y, is_subgrid_var, derived_from, istatus)
                return
             end if 
          else
@@ -1729,7 +1730,7 @@ module source_data_module
                   dimnames(3) = ' '
                end if
                
-               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, istatus)
+               call get_subgrid_dim_name(nest_num, field_name, dimnames(1:2), sr_x, sr_y, is_subgrid_var, istatus)
                field_name = dfdy_name
                units = '-'
                description = 'df/dy'
@@ -1739,7 +1740,7 @@ module source_data_module
                call get_next_output_fieldname(nest_num, field_name, ndims, &
                                               min_cat, max_cat, istagger, &
                                               memorder, dimnames, units, description, &
-                                              sr_x, sr_y, derived_from, istatus)
+                                              sr_x, sr_y, is_subgrid_var, derived_from, istatus)
                return
             end if 
          else
@@ -2546,19 +2547,21 @@ module source_data_module
    ! Pupose:
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    subroutine get_subgrid_dim_name(nest_num, field_name, dimnames, &
-                                   sub_x, sub_y, istatus)
+                                   sub_x, sub_y, is_subgrid_var, istatus)
 
       use gridinfo_module
 
       implicit none
       integer, intent(in) :: nest_num
       integer, intent(out) :: sub_x, sub_y, istatus
+      logical, intent(out) :: is_subgrid_var
       character(len=128), intent(in) :: field_name
       character(len=128), dimension(2), intent(inout) :: dimnames
       integer :: idx, nlen
 
       sub_x = 1
       sub_y = 1
+      is_subgrid_var = .false.
 
       istatus = 0
       do idx=1,num_entries
@@ -2573,6 +2576,7 @@ module source_data_module
                dimnames(2) = trim(dimnames(2))//"_subgrid"
                sub_x = subgrid_ratio_x(nest_num)
                sub_y = subgrid_ratio_y(nest_num)
+               is_subgrid_var = .true.
             end if
          end if
       end do

--- a/metgrid/src/storage_module.F
+++ b/metgrid/src/storage_module.F
@@ -345,7 +345,7 @@ call mprintf(.true.,WARN,'PLEASE REPORT THIS BUG TO THE DEVELOPER!')
    subroutine get_next_output_fieldname(nest_num, field_name, ndims, &
                                         min_level, max_level, &
                                         istagger, mem_order, dim_names, units, description, &
-                                        sr_x, sr_y, derived_from, &
+                                        sr_x, sr_y, is_subgrid_var, derived_from, &
                                         istatus)
 
       implicit none
@@ -354,6 +354,7 @@ call mprintf(.true.,WARN,'PLEASE REPORT THIS BUG TO THE DEVELOPER!')
       integer, intent(in) :: nest_num
       integer, intent(out) :: ndims, min_level, max_level, istagger, istatus
       integer, intent(out) :: sr_x, sr_y
+      logical, intent(in) :: is_subgrid_var
       character (len=128), intent(out) :: field_name, mem_order, units, description, derived_from
       character (len=128), dimension(3), intent(out) :: dim_names
 


### PR DESCRIPTION
TYPE: enhancement

KEYWORDS: subgrid, processing, fire

SOURCE: Angel Farguell and Adam Kochanski (San Jose State University), Jan Mandel (University of Colorado Denver)

DESCRIPTION OF CHANGES:
Processing subgrid variables on domains that are not needed is sometimes time-consuming. WPS release-v4.2, using geogrid table `subgrid=yes` flag, generates the subgrid variable in all the domains independent of the values of `subgrid_ratio_x` and `subgrid_ratio_y` in the namelist.wps. If `subgrid_ratio_x < 1` or `subgrid_ratio_y < 1`, the subgrid variable is generated on the atmospheric mesh. 

In this pull request, a new logical variable called `is_subgrid_var` is generated to distinguish subgrid variables and is used to determine either if a variable should be processed or not. A variable is processed if the logic `(.not. is_subgrid_var .or. (sr_x > 0 .or. sr_y > 0))` is true.

Because of this change, the user is able to control on a specific domain the next capabilities depending on the values of `subgrid_ratio_x` and `subgrid_ratio_y`:
- **Deactivate subgrid variables**: setting `subgrid_ratio_x = 0` or `subgrid_ratio_y = 0`.
- **Process subgrid variables in the atmospheric mesh**: setting `subgrid_ratio_x = 1` and `subgrid_ratio_y = 1`. 
- **Process subgrid variables in a refined mesh**: setting `subgrid_ratio_x > 1` and `subgrid_ratio_y > 1`.

LIST OF MODIFIED FILES:
M       geogrid/src/output_module.F
M       geogrid/src/process_tile_module.F
M       geogrid/src/source_data_module.F
M       metgrid/src/storage_module.F

TESTS CONDUCTED:
- [x] Feed high-resolution elevation and fuel categories from [LANDFIRE](https://landfire.cr.usgs.gov) website using geogrid table option `subgrid=yes` into WPS setting namelist.wps options `subgrid_ratio_x = 0, 1, 20` and `subgrid_ratio_y = 0, 1, 20`. 

The test case produces no subgrid variable on domain 1, subgrid variable on atmospheric mesh on domain 2, and subgrid variable on refined mesh with a ratio of 20 on domain 3.

RELEASE NOTE:
Processing subgrid variables in WPS can be expensive. In order to prevent computing them in all the domains, we suggest creating a mechanism to deactivate them. This approach gives more control and flexibility to the users that need to process subgrid variables in specific domains.