### PR TITLE
add support for non-static libnetcdff compilation

### DIFF
--- a/configure
+++ b/configure
@@ -139,7 +139,7 @@ if [ -n "$NETCDF" ] ; then
   # for 3.6.2 and greater there might be a second library, libnetcdff.a .  Check for this and use
   # if available
   NETCDFF=" "
-  if [ -f "$NETCDF/lib/libnetcdff.a" ] ; then
+  if [ -f "$NETCDF/lib/libnetcdff.a" -o -f "$NETCDF/lib/libnetcdff.so" -o -f "$NETCDF/lib/libnetcdff.dll.a" ] ; then
     NETCDFF="-lnetcdff"
   fi
 else


### PR DESCRIPTION
Although libnetcdff.so is now supported in the WRF configuration file, it has not been added to WPS. When libnetcdff.a is not present, it needs to be changed to libnetcdff.so every time. Now, with this change, WPS can be compiled with netcdf libraries that are not statically compiled, without making any changes to WPS.