### PR TITLE
Adding entries to the Metgrid table for MAD-WRF

### DIFF
--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -1148,3 +1148,19 @@ name=LOGSFP
         output=no
         interp_option=four_pt
 ========================================
+name=CLDMASK
+        interp_option=nearest_neighbor
+        flag_in_output=FLAG_CLDMASK
+========================================
+name=CLDBASEZ
+        interp_option=nearest_neighbor
+        flag_in_output=FLAG_CLDBASEZ
+========================================
+name=CLDTOPZ
+        interp_option=nearest_neighbor
+        flag_in_output=FLAG_CLDTOPZ
+========================================
+name=BRTEMP
+        interp_option=nearest_neighbor
+        flag_in_output=FLAG_BRTEMP
+========================================


### PR DESCRIPTION
MAD-WRF requires the following entries in the metgrid table. The variables are optional and can be used to improve the cloud analysis in Real.