### PR TITLE
Improve the calculation of rotation angle at sub-km grid scales

### DIFF
--- a/geogrid/src/process_tile_module.F
+++ b/geogrid/src/process_tile_module.F
@@ -1922,6 +1922,7 @@ module process_tile_module
    
       use constants_module
       use gridinfo_module
+      use map_utils, only : lc_cone
     
       implicit none
     
@@ -1932,51 +1933,136 @@ module process_tile_module
     
       ! Local variables
       integer :: i, j
+      real :: cone
       real :: alpha, d_lon
 
-      do i=start_mem_i, end_mem_i
-         do j=start_mem_j+1, end_mem_j-1
-            d_lon = xlon_arr(i,j+1)-xlon_arr(i,j-1)
+      !
+      ! Lambert conformal projection
+      !
+      if (iproj_type == PROJ_LC) then
+
+         ! Rotation angle is given by the difference in longitude from the standard longitude
+         ! scaled by the cone factor of the projection
+
+         call lc_cone(truelat1, truelat2, cone)
+
+         do i=start_mem_i, end_mem_i
+            do j=start_mem_j, end_mem_j
+               d_lon = stand_lon - xlon_arr(i,j)
+               if (d_lon > 180.) then
+                  d_lon = d_lon - 360.
+               else if (d_lon < -180.) then
+                  d_lon = d_lon + 360.
+               end if
+
+               alpha = d_lon * cone * RAD_PER_DEG
+
+               sina(i,j) = sin(alpha)
+               cosa(i,j) = cos(alpha)
+            end do
+         end do
+
+      !
+      ! Polar stereographic projection
+      !
+      else if (iproj_type == PROJ_PS) then
+
+         ! Rotation angle is given by the difference in longitude from the standard longitude
+
+         do i=start_mem_i, end_mem_i
+            do j=start_mem_j, end_mem_j
+               d_lon = stand_lon - xlon_arr(i,j)
+               if (d_lon > 180.) then
+                  d_lon = d_lon - 360.
+               else if (d_lon < -180.) then
+                  d_lon = d_lon + 360.
+               end if
+
+               alpha = d_lon * RAD_PER_DEG
+
+               sina(i,j) = sin(alpha)
+               cosa(i,j) = cos(alpha)
+            end do
+         end do
+
+      !
+      ! Mercator projection
+      !
+      else if (iproj_type == PROJ_MERC) then
+
+         ! Rotation angle is always zero
+
+         sina(:,:) = 0.0
+         cosa(:,:) = 1.0
+
+      !
+      ! Global cylindrical projection
+      !
+      else if (iproj_type == PROJ_CYL) then
+
+         ! Rotation angle is always zero
+
+         sina(:,:) = 0.0
+         cosa(:,:) = 1.0
+
+      !
+      ! Rotated global cylindrical projection
+      !
+      else if (iproj_type == PROJ_CASSINI) then
+
+         ! Compute angles using finite differences
+
+         do i=start_mem_i, end_mem_i
+            do j=start_mem_j+1, end_mem_j-1
+               d_lon = xlon_arr(i,j+1)-xlon_arr(i,j-1)
+               if (d_lon > 180.) then
+                  d_lon = d_lon - 360.
+               else if (d_lon < -180.) then
+                  d_lon = d_lon + 360.
+               end if
+
+               alpha = atan2(-cos(xlat_arr(i,j)*RAD_PER_DEG) * (d_lon*RAD_PER_DEG), &
+                               ((xlat_arr(i,j+1)-xlat_arr(i,j-1))*RAD_PER_DEG))
+               sina(i,j) = sin(alpha)
+               cosa(i,j) = cos(alpha)
+            end do
+         end do
+
+         do i=start_mem_i, end_mem_i
+            d_lon = xlon_arr(i,start_mem_j+1)-xlon_arr(i,start_mem_j)
             if (d_lon > 180.) then
                d_lon = d_lon - 360.
             else if (d_lon < -180.) then
                d_lon = d_lon + 360.
             end if
 
-            alpha = atan2(-cos(xlat_arr(i,j)*RAD_PER_DEG) * (d_lon*RAD_PER_DEG), &
-                            ((xlat_arr(i,j+1)-xlat_arr(i,j-1))*RAD_PER_DEG))
-            sina(i,j) = sin(alpha)
-            cosa(i,j) = cos(alpha)
+            alpha = atan2(-cos(xlat_arr(i,start_mem_j)*RAD_PER_DEG) * (d_lon*RAD_PER_DEG), &
+                          ((xlat_arr(i,start_mem_j+1)-xlat_arr(i,start_mem_j))*RAD_PER_DEG))
+            sina(i,start_mem_j) = sin(alpha)
+            cosa(i,start_mem_j) = cos(alpha)
          end do
-      end do
 
-      do i=start_mem_i, end_mem_i
-         d_lon = xlon_arr(i,start_mem_j+1)-xlon_arr(i,start_mem_j)
-         if (d_lon > 180.) then
-            d_lon = d_lon - 360.
-         else if (d_lon < -180.) then
-            d_lon = d_lon + 360.
-         end if
+         do i=start_mem_i, end_mem_i
+            d_lon = xlon_arr(i,end_mem_j)-xlon_arr(i,end_mem_j-1)
+            if (d_lon > 180.) then
+               d_lon = d_lon - 360.
+            else if (d_lon < -180.) then
+               d_lon = d_lon + 360.
+            end if
 
-         alpha = atan2(-cos(xlat_arr(i,start_mem_j)*RAD_PER_DEG) * (d_lon*RAD_PER_DEG), &
-                       ((xlat_arr(i,start_mem_j+1)-xlat_arr(i,start_mem_j))*RAD_PER_DEG))
-         sina(i,start_mem_j) = sin(alpha)
-         cosa(i,start_mem_j) = cos(alpha)
-      end do
+            alpha = atan2(-cos(xlat_arr(i,end_mem_j)*RAD_PER_DEG) * (d_lon*RAD_PER_DEG), &
+                          ((xlat_arr(i,end_mem_j)-xlat_arr(i,end_mem_j-1))*RAD_PER_DEG))
+            sina(i,end_mem_j) = sin(alpha)
+            cosa(i,end_mem_j) = cos(alpha)
+         end do
 
-      do i=start_mem_i, end_mem_i
-         d_lon = xlon_arr(i,end_mem_j)-xlon_arr(i,end_mem_j-1)
-         if (d_lon > 180.) then
-            d_lon = d_lon - 360.
-         else if (d_lon < -180.) then
-            d_lon = d_lon + 360.
-         end if
+      ! NMM Rotated latitude-longitude projection
+      else if (iproj_type == PROJ_ROTLL) then
 
-         alpha = atan2(-cos(xlat_arr(i,end_mem_j)*RAD_PER_DEG) * (d_lon*RAD_PER_DEG), &
-                       ((xlat_arr(i,end_mem_j)-xlat_arr(i,end_mem_j-1))*RAD_PER_DEG))
-         sina(i,end_mem_j) = sin(alpha)
-         cosa(i,end_mem_j) = cos(alpha)
-      end do
+         ! No longer supported...
+         call mprintf(.true.,ERROR,' The NMM rotated lat-lon grid is no longer supported. Rotation angles cannot be computed.')
+
+      end if
     
    end subroutine get_rotang
    


### PR DESCRIPTION
This PR improves the calculation of rotation angle at sub-km grid scales.

Previously, the sine and cosine of the rotation angle (SINALPHA and COSALPHA) were computed using finite differences of the latitude and longitude fields. This calculation generally worked well at grid scales larger than ~1 km and had the benefit of being independent of map projection. However, at smaller grid scales, the limited precision of the latitude and longitude fields led to numerical errors in the computed rotation angle.

This PR adds projection-specific code to compute the rotation angle. For the Mercator and cylindrical equidistant projections, the rotation angle is simply zero everywhere, and for the Lambert conformal conic and polar stereographic projections, the rotation angle is derived from the difference between a grid cell's longitude and the standard longitude. For the Cassini projection, a formula for the rotation angle is difficult to derive, and so with the expectation that this projection will find limited use at high resolution, the same finite differencing scheme is still employed.