### PR TITLE
Support 9-character variable names in ungrib

### DIFF
--- a/ungrib/src/new_storage.F
+++ b/ungrib/src/new_storage.F
@@ -16,7 +16,7 @@ module storage_module
   public :: setll
   public :: getll
 
-  integer, parameter :: idlen = 8
+  integer, parameter :: idlen = 9
   integer :: verbose = 0  ! 0 = no prints; 1 = some prints; 2 = more; etc.
 
   type node2

--- a/ungrib/src/output.F
+++ b/ungrib/src/output.F
@@ -80,7 +80,7 @@ subroutine output(hdate, nlvl, maxlvl, plvl, interval, iflag, out_format, prefix
      do k = 1, n-1
         if (namvar(k).eq.namvar(n)) cycle WRTLOOP
      enddo
-     write(*,advance='NO', fmt='(1x,A8)') namvar(n)
+     write(*,advance='NO', fmt='(1x,A9)') namvar(n)
      write(tmp9,'(A9)') namvar(n)(1:9)
      call right_justify(tmp9,9)
      call mprintf(.true.,LOGFILE,tmp9,newline=.false.)


### PR DESCRIPTION
This PR enables support for 9-character variable names in ungrib. Prior to the changes in this PR, the variables were only properly handled if their names contained up to 8 characters.

The focus on support for 9 characters (rather than 10, 11, or more) in variable names is justified by the fact that the code to parse Vtables, as well as the intermediate file format, already support 9-character names.