### PR TITLE
Support for dwd suite of models

### DIFF
--- a/README.icon
+++ b/README.icon
@@ -1,13 +1,14 @@
 #########################################################################
 README for running ICON suite of models - ICON-eu, ICON-d2 and ICON global
 
-Icon data can be downloaded from the opdate data server - 
+Icon data can be downloaded from the open data server - 
 https://opendata.dwd.de/weather/nwp/
 
 Archive data server information can be found at (not free) - 
 https://www.dwd.de/EN/ourservices/pamore/pamore.html 
 
-For all model data you need to HSURF which is the geometric height of the earts surface above msl. Can use cdo to merge this file into each timestep after downloading it for each timestep.
+For all model data you need to include variable HSURF which is the geometric height of the earths surface above msl. Can use cdo to merge this file into each timestep after downloading it for each timestep.
+Time needs to be corrected for each timestep on download if downloading from open data server. This can be done by using cdo -setdate,"$date" -settime,"$Tstad":00:00 with date being year, month and day of the model timestep and Tstad is hour of model timestep. 
 
 #########################################################################
 Soil data - all DWD models
@@ -25,7 +26,7 @@ ICON-EU and icon-d2
 Can be run using pressure levels or model level data. 
 
 Variable tables labelled as pressure_level or model_level.
-Note different variables are downloaded depending on what variable tables you are using due to some variable not. 
+Note different variables are downloaded depending on what variable tables you are using due to some variables not available on the open data server for that model. 
 
 
 ##########################################################################

--- a/README.icon
+++ b/README.icon
@@ -1,0 +1,56 @@
+#########################################################################
+README for running ICON suite of models - ICON-eu, ICON-d2 and ICON global
+
+Icon data can be downloaded from the opdate data server - 
+https://opendata.dwd.de/weather/nwp/
+
+Archive data server information can be found at (not free) - 
+https://www.dwd.de/EN/ourservices/pamore/pamore.html 
+
+For all model data you need to HSURF which is the geometric height of the earts surface above msl. Can use cdo to merge this file into each timestep after downloading it for each timestep.
+
+#########################################################################
+Soil data - all DWD models
+
+All the icon models and DWD suite of models output 9 soil temperature levels and 8 soil moisture layers. For running with wrf you can use however many levels you need, however soil level 0 is needed. 
+This 0 layer is layer 1 of 8 in the soil moisture levels. For temperature you can either use layer 0 or 1 at depths 0cm or 0.5cm as a zero gradient conditions is assumed between these levels. For ease of download level 0 is easiest to download.
+For layers 1 to 6 these are prognosed in soil moisture, however for soil moisture layers 7 and 8 these are considered zero gradient condition and filled the same as level 6.
+Temperatures are prognosed from layers 1 to 7 with layer 8 filled with the climatological average 2m temperature so caution should be used when using this layer in soil models.
+
+Soil moisture should be fed into ungrib as kg/m2 so metgrid then turns this into a fraction so WRF can use it.
+
+#########################################################################
+ICON-EU and icon-d2
+
+Can be run using pressure levels or model level data. 
+
+Variable tables labelled as pressure_level or model_level.
+Note different variables are downloaded depending on what variable tables you are using due to some variable not. 
+
+
+##########################################################################
+ICON-Global
+
+Can be run using pressure level data or model level data.
+
+Variable tables labelled as pressure_level and model_level.
+
+Data needs to be converted from icosahedral grid to latlon grid.
+
+To convert to latlong grid from native icosahedral grid yo ucan use various tools -
+https://www.dwd.de/DE/leistungen/opendata/help/modelle/Opendata_cdo_EN.pdf?__blob=publicationFile&v=3
+https://github.com/DeutscherWetterdienst/regrid
+
+########################################################################
+________________________________________
+        |Pressure level | Model level  |
+        |---------------|--------------|
+        |               |              |
+Icon-EU |      Yes      |      Yes     |
+________|_______________|______________|
+        |               |              |
+ICON-d2 |      Yes      |      Yes     |
+________|_______________|______________|
+        |               |              |
+ICON-   |      Yes      |      Yes     |   ICON Global is on icosahedral grid so needs to be converted to latlon grid before (See notes above)
+global  |_______________|______________|

--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -76,7 +76,16 @@ name=SOILM
         fill_lev =  10 : SOILM010(200100)      
         fill_lev =  30 : SOILM030(200100)      
         fill_lev =  60 : SOILM060(200100)      
-        fill_lev = 100 : SOILM100(200100)      
+        fill_lev = 100 : SOILM100(200100)
+# ICON
+        fill_lev =   0 : SOILM000(200100)
+        fill_lev =   2 : SOILM002(200100)
+        fill_lev =   6 : SOILM006(200100)
+        fill_lev =  18 : SOILM018(200100)
+        fill_lev =  54 : SOILM054(200100)
+        fill_lev = 162 : SOILM162(200100)
+        fill_lev = 486 : SOILM486(200100)
+        fill_lev = 1458 : SOILM999(200100)  
 ========================================
 name=SOILT
         z_dim_name=num_soilt_levels
@@ -95,7 +104,16 @@ name=SOILT
         fill_lev =  10 : SOILT010(200100)      
         fill_lev =  30 : SOILT030(200100)      
         fill_lev =  60 : SOILT060(200100)      
-        fill_lev = 100 : SOILT100(200100)      
+        fill_lev = 100 : SOILT100(200100) 
+#ICON
+        fill_lev =   0 : SOILT000(200100)
+        fill_lev =   2 : SOILT002(200100)
+        fill_lev =   6 : SOILT006(200100)
+        fill_lev =  18 : SOILT018(200100)
+        fill_lev =  54 : SOILT054(200100)
+        fill_lev = 162 : SOILT162(200100)
+        fill_lev = 486 : SOILT486(200100)
+        fill_lev = 1458 : SOILT999(200100)
 ========================================
 name=SOIL_LEVELS
         derived=yes
@@ -401,6 +419,13 @@ name=SOILM001
         fill_missing=1.
         flag_in_output=FLAG_SOILM001
 ========================================
+name=SOILM002
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM002
+========================================
 name=SOILM004
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
@@ -415,12 +440,26 @@ name=SOILM005
         fill_missing=1.
         flag_in_output=FLAG_SOILM005
 ========================================
+name=SOILM006
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM006
+========================================
 name=SOILM010
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM010
+========================================
+name=SOILM018
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM018
 ========================================
 name=SOILM020
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
@@ -443,6 +482,13 @@ name=SOILM040
         fill_missing=1.
         flag_in_output=FLAG_SOILM040
 ========================================
+name=SOILM054
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM054
+========================================
 name=SOILM060
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
@@ -464,12 +510,33 @@ name=SOILM160
         fill_missing=1.
         flag_in_output=FLAG_SOILM160
 ========================================
+name=SOILM162
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM162
+========================================
 name=SOILM300
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM300
+========================================
+name=SOILM486
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM486
+========================================
+name=SOILM999
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM999
 ========================================
 name=SOILT000
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
@@ -485,6 +552,13 @@ name=SOILT001
         fill_missing=285.
         flag_in_output=FLAG_SOILT001
 ========================================
+name=SOILT002
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT002
+========================================
 name=SOILT004
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
@@ -499,12 +573,26 @@ name=SOILT005
         fill_missing=285.
         flag_in_output=FLAG_SOILT005
 ========================================
+name=SOILT006
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT006
+========================================
 name=SOILT010
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=285.
         flag_in_output=FLAG_SOILT010
+========================================
+name=SOILT018
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT018
 ========================================
 name=SOILT020
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
@@ -527,6 +615,13 @@ name=SOILT040
         fill_missing=285.
         flag_in_output=FLAG_SOILT040
 ========================================
+name=SOILT054
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT054
+========================================
 name=SOILT060
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
@@ -548,12 +643,33 @@ name=SOILT160
         fill_missing=285.
         flag_in_output=FLAG_SOILT160
 ========================================
+name=SOILT162
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT162
+========================================
 name=SOILT300
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=285.
         flag_in_output=FLAG_SOILT300
+========================================
+name=SOILT486
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT486
+========================================
+name=SOILT999
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT999
 ========================================
 name=SOILT050
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
@@ -630,6 +746,15 @@ mpas_name=uReconstructMeridional
         interp_option=sixteen_pt+four_pt+average_4pt
         is_v_field=yes
         output_stagger=V
+        fill_missing=0.
+        fill_lev=200100:const(-1.E30)
+========================================
+name=W ; output_name=WW  # If we get W, use entry from WW and
+                         #   write the field out as WW
+========================================
+name=WW
+        interp_option=sixteen_pt+four_pt+average_4pt
+        output_stagger=W
         fill_missing=0.
         fill_lev=200100:const(-1.E30)
 ========================================
@@ -726,6 +851,10 @@ mpas_name=zgrid
         fill_lev=200100:HGT_M(1)
 ========================================
 name=HGTT
+        output=no
+        interp_option=nearest_neighbor
+========================================
+name=GEOPT
         output=no
         interp_option=nearest_neighbor
 ========================================

--- a/ungrib/Variable_Tables/README
+++ b/ungrib/Variable_Tables/README
@@ -49,6 +49,7 @@ Vtable.TCRP                Twentieth Century Global Reanalysis Version 2
 Vtable.UKMO_ENDGame        U.K. Met Office model
 Vtable.UKMO_LANDSEA
 Vtable.UKMO_no_heights
+Vtable.ICON_pressure_levels  DWD ICON-EU pressure level
+Vtable.ICON_model_levels     DWD ICON/ICON EU model levels
 
-
-Updated 12 Aug 2014
+Updated 31 Mar 2023

--- a/ungrib/Variable_Tables/Vtable.ICON_model_levels
+++ b/ungrib/Variable_Tables/Vtable.ICON_model_levels
@@ -38,7 +38,7 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
 -----+------+------+------+----------+---------+--------------------------------------
 #
 #
-#  Vtable for Icon-EU model levels from the dwd server.
+#  Vtable for Icon-EU and ICON model levels from the dwd server.
 #
 # https://opendata.dwd.de/weather/nwp/
 #
@@ -46,7 +46,7 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
 # Variable from server come as individual files per variable and timestep so need to merge them together.
 # Some variable only come for initial time so need to be added for each timestep being ingested into wps.
 #
-# Due to model levels being on .5 levels then need to convert these to whole model levels before running ungrib 
-#Can be done using CDO command (cdo -setzaxis,"zaxis.tmp" Fin Fout) for each variable) where zaxis.tmp includes the whole model levels to nearest whole level.
+# 
+#
 # 
 #

--- a/ungrib/Variable_Tables/Vtable.ICON_model_levels
+++ b/ungrib/Variable_Tables/Vtable.ICON_model_levels
@@ -1,0 +1,52 @@
+GRIB1| Level| From |  To  | metgrid  | metgrid | metgrid                                 |GRIB2|GRIB2|GRIB2|GRIB2|
+Param| Type |Level1|Level2| Name     | Units   | Description                             |Discp|Catgy|Param|Level|
+-----+------+------+------+----------+---------+-----------------------------------------+-----------------------+
+  11 | 109  |   *  |      | TT       | K       | Temperature                             |  0  |  0  |  0  | 150 |
+  33 | 109  |   *  |      | UU       | m s-1   | U                                       |  0  |  2  |  2  | 150 |
+  34 | 109  |   *  |      | VV       | m s-1   | V                                       |  0  |  2  |  3  | 150 |
+   1 | 109  |   *  |      | PRESSURE | Pa      | Pressure                                |  0  |  3  |  0  | 150 |
+  51 | 109  |   *  |      | SPECHUMD | kg kg-1 | Specific Humidity                       |  0  |  1  |  0  | 150 |
+  11 | 105  |   2  |      | TT       | K       | Temperature       at 2 m                |  0  |  0  |  0  | 103 |
+  33 | 105  |  10  |      | UU       | m s-1   | U                 at 10 m               |  0  |  2  |  2  | 103 |
+  34 | 105  |  10  |      | VV       | m s-1   | V                 at 10 m               |  0  |  2  |  3  | 103 |
+  52 | 105  |   2  |      | RH       | %       | Relative Humidity at 2 m                |  0  |  1  |  1  | 103 |
+   1 |   1  |   0  |      | PSFC     | Pa      | Surface Pressure                        |  0  |  3  |  0  |   1 |
+   2 | 102  |   0  |      | PMSL     | Pa      | Sea-level Pressure                      |  0  |  3  |  1  | 101 |
+ 144 | 112  |   0  |   1  | SOILM000 | Fraction| Soil Moist 0.5 cm                       |  2  |  3  | 20  | 106 |
+ 144 | 112  |   1  |   3  | SOILM002 | Fraction| Soil Moist 2 cm                         |  2  |  3  | 20  | 106 |
+ 144 | 112  |   3  |   9  | SOILM006 | Fraction| Soil Moist 6 cm                         |  2  |  3  | 20  | 106 |
+ 144 | 112  |  9   |  27  | SOILM018 | Fraction| Soil Moist 18 cm                        |  2  |  3  | 20  | 106 |
+ 144 | 112  |  27  |  81  | SOILM054 | Fraction| Soil Moist 54 cm                        |  2  |  3  | 20  | 106 |
+ 144 | 112  |  81  | 243  | SOILM162 | Fraction| Soil Moist 162 cm                       |  2  |  3  | 20  | 106 |
+ 144 | 112  | 243  | 729  | SOILM486 | Fraction| Soil Moist 486 cm                       |  2  |  3  | 20  | 106 |
+ 144 | 112  | 729  | 2187 | SOILM999 | Fraction| Soil Moist 1458 cm                      |  2  |  3  | 20  | 106 |
+  11 | 111  |   0  |      | SOILT000 | K       | Soil Temperature 0.5/0 cm               |  2  |  3  | 18  | 106 |
+  11 | 111  |   2  |      | SOILT002 | K       | Soil Temperature 2 cm                   |  2  |  3  | 18  | 106 |
+  11 | 111  |   6  |      | SOILT006 | K       | Soil Temperature 6 cm                   |  2  |  3  | 18  | 106 |
+  11 | 111  |  18  |      | SOILT018 | K       | Soil Temperature 18 cm                  |  2  |  3  | 18  | 106 |
+  11 | 111  |  54  |      | SOILT054 | K       | Soil Temperature 54 cm                  |  2  |  3  | 18  | 106 |
+  11 | 111  | 162  |      | SOILT162 | K       | Soil Temperature 162 cm                 |  2  |  3  | 18  | 106 |
+  11 | 111  | 486  |      | SOILT486 | K       | Soil Temperature 486 cm                 |  2  |  3  | 18  | 106 |
+  11 | 111  |1458  |      | SOILT999 | K       | Soil Temperature 1458 cm                |  2  |  3  | 18  | 106 |
+  81 |   1  |   0  |      | LANDSEA  | proprtn | Land/Sea flag (1=land, 0 or 2=sea)      |  2  |  0  |  0  |   1 |
+   7 |   1  |   0  |      | SOILHGT  | m       | Terrain field of source analysis        |  0  |  3  |  6  |   1 |
+  11 |   1  |   0  |      | SKINTEMP | K       | Skin temperature                        |  0  |  0  |  0  |   1 |
+  65 |   1  |   0  |      | SNOW     | kg m-2  | Snow depth water equivalent             |  0  |  1  | 60  |   1 |
+     |   1  |   0  |      | SNOWH    | m       | Physical Snow Depth                     |  0  |  1  | 11  |   1 |
+  51 | 105  |   2  |      | SPECHUMD | kg kg-1 | Specific Humidity at 2 m                |  0  |  1  |  0  | 103 |
+     | 109  |   *  |      | WW       | m s-1   | W                                       |  0  |  2  |  9  | 150 |
+-----+------+------+------+----------+---------+--------------------------------------
+#
+#
+#  Vtable for Icon-EU model levels from the dwd server.
+#
+# https://opendata.dwd.de/weather/nwp/
+#
+# Notes:
+# Variable from server come as individual files per variable and timestep so need to merge them together.
+# Some variable only come for initial time so need to be added for each timestep being ingested into wps.
+#
+# Due to model levels being on .5 levels then need to convert these to whole model levels before running ungrib 
+#Can be done using CDO command (cdo -setzaxis,"zaxis.tmp" Fin Fout) for each variable) where zaxis.tmp includes the whole model levels to nearest whole level.
+# 
+#

--- a/ungrib/Variable_Tables/Vtable.ICON_pressure_levels
+++ b/ungrib/Variable_Tables/Vtable.ICON_pressure_levels
@@ -1,0 +1,49 @@
+GRIB1| Level| From |  To  | metgrid  | metgrid | metgrid                                 |GRIB2|GRIB2|GRIB2|GRIB2|
+Param| Type |Level1|Level2| Name     | Units   | Description                             |Discp|Catgy|Param|Level|
+-----+------+------+------+----------+---------+-----------------------------------------+-----------------------+
+  11 | 100  |   *  |      | TT       | K       | Temperature                             |  0  |  0  |  0  | 100 |
+  33 | 100  |   *  |      | UU       | m s-1   | U                                       |  0  |  2  |  2  | 100 |
+  34 | 100  |   *  |      | VV       | m s-1   | V                                       |  0  |  2  |  3  | 100 |
+  52 | 100  |   *  |      | RH       | %       | Relative Humidity                       |  0  |  1  |  1  | 100 |
+ 129 | 100  |   *  |      | GEOPT    | m2 s-2  | Geopotential                            |  0  |  3  |  4  | 100 |
+     | 100  |   *  |      | HGT      | m       | Height                                  |     |     |     | 100 |
+  11 | 105  |   2  |      | TT       | K       | Temperature       at 2 m                |  0  |  0  |  0  | 103 |
+  33 | 105  |  10  |      | UU       | m s-1   | U                 at 10 m               |  0  |  2  |  2  | 103 |
+  34 | 105  |  10  |      | VV       | m s-1   | V                 at 10 m               |  0  |  2  |  3  | 103 |
+  52 | 105  |   2  |      | RH       | %       | Relative Humidity at 2 m                |  0  |  1  |  1  | 103 |
+   1 |   1  |   0  |      | PSFC     | Pa      | Surface Pressure                        |  0  |  3  |  0  |   1 |
+   2 | 102  |   0  |      | PMSL     | Pa      | Sea-level Pressure                      |  0  |  3  |  1  | 101 |
+ 144 | 112  |   0  |  1   | SOILM000 | kg m-2  | Soil Moist 0.5 cm                       |  2  |  3  | 20  | 106 |
+ 144 | 112  |   1  |  3   | SOILM002 | kg m-2  | Soil Moist 2 cm                         |  2  |  3  | 20  | 106 |
+ 144 | 112  |   3  |  9   | SOILM006 | kg m-2  | Soil Moist 6 cm                         |  2  |  3  | 20  | 106 |
+ 144 | 112  |  9   | 27   | SOILM018 | kg m-2  | Soil Moist 18 cm                        |  2  |  3  | 20  | 106 |
+ 144 | 112  |  27  | 81   | SOILM054 | kg m-2  | Soil Moist 54 cm                        |  2  |  3  | 20  | 106 |
+ 144 | 112  |  81  | 243  | SOILM162 | kg m-2  | Soil Moist 162 cm                       |  2  |  3  | 20  | 106 |
+ 144 | 112  | 243  | 729  | SOILM486 | kg m-2  | Soil Moist 486 cm                       |  2  |  3  | 20  | 106 |
+ 144 | 112  | 729  | 2187 | SOILM999 | kg m-2  | Soil Moist 1458 cm                      |  2  |  3  | 20  | 106 |
+  11 | 111  |   0  |      | SOILT000 | K       | Soil Temperature 0/0.5 cm               |  2  |  3  | 18  | 106 |
+  11 | 111  |   2  |      | SOILT002 | K       | Soil Temperature 2 cm                   |  2  |  3  | 18  | 106 |
+  11 | 111  |   6  |      | SOILT006 | K       | Soil Temperature 6 cm                   |  2  |  3  | 18  | 106 |
+  11 | 111  |  18  |      | SOILT018 | K       | Soil Temperature 18 cm                  |  2  |  3  | 18  | 106 |
+  11 | 111  |  54  |      | SOILT054 | K       | Soil Temperature 54 cm                  |  2  |  3  | 18  | 106 |
+  11 | 111  | 162  |      | SOILT162 | K       | Soil Temperature 162 cm                 |  2  |  3  | 18  | 106 |
+  11 | 111  | 486  |      | SOILT486 | K       | Soil Temperature 486 cm                 |  2  |  3  | 18  | 106 |
+  11 | 111  |1458  |      | SOILT999 | K       | Soil Temperature 1458 cm                |  2  |  3  | 18  | 106 |
+  81 |   1  |   0  |      | LANDSEA  | proprtn | Land/Sea flag (1=land, 0 or 2=sea)      |  2  |  0  |  0  |   1 |
+   7 |   1  |   0  |      | SOILHGT  | m       | Terrain field of source analysis        |  0  |  3  |  6  |   1 |
+  11 |   1  |   0  |      | SKINTEMP | K       | Skin temperature                        |  0  |  0  |  0  |   1 |
+  65 |   1  |   0  |      | SNOW     | kg m-2  | Snow depth water equivalent             |  0  |  1  | 60  |   1 |
+     |   1  |   0  |      | SNOWH    | m       | Physical Snow Depth                     |  0  |  1  | 11  |   1 |
+-----+------+------+------+----------+---------+--------------------------------------
+#
+#
+#  Vtable for Icon-EU pressure levels from the dwd server.
+#
+# https://opendata.dwd.de/weather/nwp/
+#
+# Variables from server come as individual files per variable and timestep so need to merge them together.
+# Some variable only come for initial time so need to be added for each timestep being ingested into wps.
+#
+# 
+# 
+#

--- a/ungrib/src/rd_grib1.F
+++ b/ungrib/src/rd_grib1.F
@@ -217,6 +217,8 @@ SUBROUTINE rd_grib1(IUNIT, gribflnm, level, field, hdate,  &
       map%source = 'ECMWF'
   else if (icenter .eq. 74 .or. icenter .eq. 75 ) then
       map%source = 'UKMO'
+  else if (icenter .eq. 78 .or. icenter .eq. 79 ) then
+      map%source = 'DWD'
   else
     map%source = 'unknown model and orig center'
   end if

--- a/ungrib/src/rd_grib2.F
+++ b/ungrib/src/rd_grib2.F
@@ -759,7 +759,7 @@ C  SET ARGUMENTS
      &                           (10. ** (-1. * gfld%ipdtmpl(11)))
 		 if ( level .lt. pmin ) cycle MATCH_LOOP
               elseif((gfld%ipdtmpl(10).eq.105).or.
-     &               (gfld%ipdtmpl(10).eq.118)).or.
+     &               (gfld%ipdtmpl(10).eq.118).or.
      &               (gfld%ipdtmpl(10).eq.150))then
                  ! Hybrid level (range from 1 to N)
                  level=gfld%ipdtmpl(12)

--- a/ungrib/src/rd_grib2.F
+++ b/ungrib/src/rd_grib2.F
@@ -326,6 +326,8 @@ C  SET ARGUMENTS
              map%source = 'JMA'
            else if (icenter .eq. 74 .or. icenter .eq. 75 ) then
              map%source = 'UKMO'
+	   else if (icenter .eq. 78 .or. icenter .eq. 79 ) then
+             map%source = 'DWD'
            else
              map%source = 'unknown model and orig center'
            end if
@@ -757,7 +759,8 @@ C  SET ARGUMENTS
      &                           (10. ** (-1. * gfld%ipdtmpl(11)))
 		 if ( level .lt. pmin ) cycle MATCH_LOOP
               elseif((gfld%ipdtmpl(10).eq.105).or.
-     &               (gfld%ipdtmpl(10).eq.118))then
+     &               (gfld%ipdtmpl(10).eq.118)).or.
+     &               (gfld%ipdtmpl(10).eq.150))then
                  ! Hybrid level (range from 1 to N)
                  level=gfld%ipdtmpl(12)
               elseif(gfld%ipdtmpl(10).eq.104) then

--- a/ungrib/src/rrpr.F
+++ b/ungrib/src/rrpr.F
@@ -1484,7 +1484,7 @@ subroutine fix_icon_soilm (ix, jx)
   call get_storage(200100, 'SOILM486', soilm486, ix, jx)
   call get_storage(200100, 'SOILM999', soilm999, ix, jx)
     !convert kg m-2 to m3 m-3
-    soilm001 = soilm000 / 10.
+    soilm000 = soilm000 / 10.
     soilm002 = soilm002 / 20.
     soilm006 = soilm006 / 60.
     soilm018 = soilm018 / 180.

--- a/ungrib/src/rrpr.F
+++ b/ungrib/src/rrpr.F
@@ -789,7 +789,16 @@ subroutine rrpr(hstart, ntimes, interval, nlvl, maxlvl, plvl, &
               call fix_ruc_soilm (map%nx, map%ny)
             endif
        endif
-
+! Convert soil moisture in ICON input from kg m-2 to m3 m-3      
+       if (index(map%source,'DWD') .ne. 0) then
+          if (is_there(200100, 'SOILM000')) then
+           call get_dims(200100, 'SOILM000')
+              print *,'Adjusting ICON soil moisture'
+           call mprintf(.true.,DEBUG, &
+              "RRPR:   Adjusting ICON soil moisture ")
+           call fix_icon_soilm (map%nx, map%ny)           
+          endif
+       endif
 !
 ! Check to see if we need to fill SOILHGT from SOILGEO.
 ! (From Wei Wang, 2007 June 21)
@@ -1451,3 +1460,56 @@ subroutine fix_gefs_landmask (ix, jx, plvl)
     deallocate (sea)
   endif
 end subroutine fix_gefs_landmask
+
+subroutine fix_icon_soilm (ix, jx)
+  use storage_module
+  implicit none
+  integer :: ix, jx
+  real, allocatable, dimension(:,:) :: soilm000, soilm002, soilm006, &
+                     soilm018, soilm054, soilm162, soilm486, soilm999
+  allocate(soilm000(ix,jx))
+  allocate(soilm002(ix,jx))
+  allocate(soilm006(ix,jx))
+  allocate(soilm018(ix,jx))
+  allocate(soilm054(ix,jx))
+  allocate(soilm162(ix,jx))
+  allocate(soilm486(ix,jx))
+  allocate(soilm999(ix,jx))
+  call get_storage(200100, 'SOILM000', soilm000, ix, jx)
+  call get_storage(200100, 'SOILM002', soilm002, ix, jx)
+  call get_storage(200100, 'SOILM006', soilm006, ix, jx)
+  call get_storage(200100, 'SOILM018', soilm018, ix, jx)
+  call get_storage(200100, 'SOILM054', soilm054, ix, jx)
+  call get_storage(200100, 'SOILM162', soilm162, ix, jx)
+  call get_storage(200100, 'SOILM486', soilm486, ix, jx)
+  call get_storage(200100, 'SOILM999', soilm999, ix, jx)
+    !convert kg m-2 to m3 m-3
+    soilm001 = soilm000 / 10.
+    soilm002 = soilm002 / 20.
+    soilm006 = soilm006 / 60.
+    soilm018 = soilm018 / 180.
+    soilm054 = soilm054 / 540.
+    soilm162 = soilm162 / 1620.
+    soilm486 = soilm486 / 4860.
+    soilm999 = soilm999 / 14580.
+  call put_storage(200100, 'SOILM000', soilm000, ix, jx)
+  call put_storage(200100, 'SOILM002', soilm002, ix, jx)
+  call put_storage(200100, 'SOILM006', soilm006, ix, jx)
+  call put_storage(200100, 'SOILM018', soilm018, ix, jx)
+  call put_storage(200100, 'SOILM054', soilm054, ix, jx)
+  call put_storage(200100, 'SOILM162', soilm162, ix, jx)
+  call put_storage(200100, 'SOILM486', soilm486, ix, jx)
+  call put_storage(200100, 'SOILM999', soilm999, ix, jx)
+
+ print *,'fix_icon_soilm is done!'
+
+  deallocate(soilm000)
+  deallocate(soilm002)
+  deallocate(soilm006)
+  deallocate(soilm018)
+  deallocate(soilm054)
+  deallocate(soilm162)
+  deallocate(soilm486)
+  deallocate(soilm999)
+
+end subroutine fix_icon_soilm


### PR DESCRIPTION
Addition of DWD suite of models, specifically the ICON models.

1.New Vtables created for icon pressure levels and models levels
2.ReadMe.icon added to add information about the running and downloading specifics needed to run the icon data through WPS.
3.Addition of DWD identifier in rd_grib2.f and rd_grib1.f, plus the addition of level code 150 in rd_grib2.f as icon-eu model levels are on generalized vertical height coordinates. 
4.Addition of new soil levels for moisture and temperatures, plus WW and GEOPT as an optional variable to be processed by metgrid as this is available from the ICON suite of models. File changed for this is METGRID.TBL.ARW
5. rrpr.F changed to add conversion of icon soil moisture to correct units from kg m-2 to m3 m-2 based on if level 0 is present and the model is DWD from the grib file.


Data from PR154 https://github.com/wrf-model/WPS/pull/154 should work and be sufficient for testing.
If any other testing is needed i can provide sample run scripts.