### PR TITLE
Adding support for ICON in WPS

### DIFF
--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -76,7 +76,16 @@ name=SOILM
         fill_lev =  10 : SOILM010(200100)      
         fill_lev =  30 : SOILM030(200100)      
         fill_lev =  60 : SOILM060(200100)      
-        fill_lev = 100 : SOILM100(200100)      
+        fill_lev = 100 : SOILM100(200100)
+# ICON
+        fill_lev =   0 : SOILM000(200100)
+        fill_lev =   2 : SOILM002(200100)
+        fill_lev =   6 : SOILM006(200100)
+        fill_lev =  18 : SOILM018(200100)
+        fill_lev =  54 : SOILM054(200100)
+        fill_lev = 162 : SOILM162(200100)
+        fill_lev = 486 : SOILM486(200100)
+        fill_lev = 1458 : SOILM999(200100)
 ========================================
 name=SOILT
         z_dim_name=num_soilt_levels
@@ -95,7 +104,16 @@ name=SOILT
         fill_lev =  10 : SOILT010(200100)      
         fill_lev =  30 : SOILT030(200100)      
         fill_lev =  60 : SOILT060(200100)      
-        fill_lev = 100 : SOILT100(200100)      
+        fill_lev = 100 : SOILT100(200100)
+#ICON
+        fill_lev =   0 : SOILT000(200100)
+        fill_lev =   2 : SOILT002(200100)
+        fill_lev =   6 : SOILT006(200100)
+        fill_lev =  18 : SOILT018(200100)
+        fill_lev =  54 : SOILT054(200100)
+        fill_lev = 162 : SOILT162(200100)
+        fill_lev = 486 : SOILT486(200100)
+        fill_lev = 1458 : SOILT999(200100)
 ========================================
 name=SOIL_LEVELS
         derived=yes
@@ -401,6 +419,13 @@ name=SOILM001
         fill_missing=1.
         flag_in_output=FLAG_SOILM001
 ========================================
+name=SOILM002
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM002
+========================================
 name=SOILM004
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
@@ -415,12 +440,26 @@ name=SOILM005
         fill_missing=1.
         flag_in_output=FLAG_SOILM005
 ========================================
+name=SOILM006
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM006
+========================================
 name=SOILM010
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM010
+========================================
+name=SOILM018
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM018
 ========================================
 name=SOILM020
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
@@ -443,6 +482,13 @@ name=SOILM040
         fill_missing=1.
         flag_in_output=FLAG_SOILM040
 ========================================
+name=SOILM054
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM054
+========================================
 name=SOILM060
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
@@ -464,12 +510,33 @@ name=SOILM160
         fill_missing=1.
         flag_in_output=FLAG_SOILM160
 ========================================
+name=SOILM162
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM162
+========================================
 name=SOILM300
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=1.
         flag_in_output=FLAG_SOILM300
+========================================
+name=SOILM486
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM486
+========================================
+name=SOILM999
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=1.
+        flag_in_output=FLAG_SOILM999
 ========================================
 name=SOILT000
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
@@ -485,6 +552,13 @@ name=SOILT001
         fill_missing=285.
         flag_in_output=FLAG_SOILT001
 ========================================
+name=SOILT002
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT002
+========================================
 name=SOILT004
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
@@ -499,12 +573,26 @@ name=SOILT005
         fill_missing=285.
         flag_in_output=FLAG_SOILT005
 ========================================
+name=SOILT006
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT006
+========================================
 name=SOILT010
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=285.
         flag_in_output=FLAG_SOILT010
+========================================
+name=SOILT018
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT018
 ========================================
 name=SOILT020
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
@@ -527,6 +615,13 @@ name=SOILT040
         fill_missing=285.
         flag_in_output=FLAG_SOILT040
 ========================================
+name=SOILT054
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT054
+========================================
 name=SOILT060
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
@@ -548,12 +643,33 @@ name=SOILT160
         fill_missing=285.
         flag_in_output=FLAG_SOILT160
 ========================================
+name=SOILT162
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT162
+========================================
 name=SOILT300
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         masked=water
         interp_mask=LANDSEA(0)
         fill_missing=285.
         flag_in_output=FLAG_SOILT300
+========================================
+name=SOILT486
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT486
+========================================
+name=SOILT999
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
+        masked=water
+        interp_mask=LANDSEA(0)
+        fill_missing=285.
+        flag_in_output=FLAG_SOILT999
 ========================================
 name=SOILT050
         interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search

--- a/ungrib/Variable_Tables/README
+++ b/ungrib/Variable_Tables/README
@@ -49,6 +49,7 @@ Vtable.TCRP                Twentieth Century Global Reanalysis Version 2
 Vtable.UKMO_ENDGame        U.K. Met Office model
 Vtable.UKMO_LANDSEA
 Vtable.UKMO_no_heights
+Vtable.ICONm               DWD ICON model level
+Vtable.ICONp               DWD ICON pressure level
 
-
-Updated 12 Aug 2014
+Updated 01 Apr 2023

--- a/ungrib/Variable_Tables/Vtable.ICONm
+++ b/ungrib/Variable_Tables/Vtable.ICONm
@@ -43,6 +43,3 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
 # Notes:
 # Variable from server come as individual files per variable and timestep so need to merge them together.
 # Some variable only come for initial time so need to be added for each timestep being ingested into wps.
-#
-# Due to model levels being on .5 levels then need to convert these to whole model levels before running ungrib 
-# Can be done using CDO command (cdo -setzaxis,"zaxis.tmp" Fin Fout) for each variable)

--- a/ungrib/Variable_Tables/Vtable.ICONm
+++ b/ungrib/Variable_Tables/Vtable.ICONm
@@ -1,0 +1,48 @@
+GRIB1| Level| From |  To  | metgrid  | metgrid | metgrid                                 |GRIB2|GRIB2|GRIB2|GRIB2|
+Param| Type |Level1|Level2| Name     | Units   | Description                             |Discp|Catgy|Param|Level|
+-----+------+------+------+----------+---------+-----------------------------------------+-----------------------+
+   8 | 109  |   *  |      | HGT      | m       | Height                                  |  0  |  3  |  6  | 150 |
+   1 | 109  |   *  |      | PRESSURE | Pa      | Pressure                                |  0  |  3  |  0  | 150 |
+  11 | 109  |   *  |      | TT       | K       | Temperature                             |  0  |  0  |  0  | 150 |
+  33 | 109  |   *  |      | UU       | m s-1   | U                                       |  0  |  2  |  2  | 150 |
+  34 | 109  |   *  |      | VV       | m s-1   | V                                       |  0  |  2  |  3  | 150 |
+  51 | 109  |   *  |      | SPECHUMD | kg kg-1 | Specific Humidity                       |  0  |  1  |  0  | 150 |
+  11 | 105  |   2  |      | TT       | K       | Temperature       at 2 m                |  0  |  0  |  0  | 103 |
+  51 | 105  |   2  |      | SPECHUMD | kg kg-1 | Specific Humidity at 2 m                |  0  |  1  |  0  | 103 |
+  52 | 105  |   2  |      | RH       | %       | Relative Humidity at 2 m                |  0  |  1  |  1  | 103 |
+  33 | 105  |  10  |      | UU       | m s-1   | U                 at 10 m               |  0  |  2  |  2  | 103 |
+  34 | 105  |  10  |      | VV       | m s-1   | V                 at 10 m               |  0  |  2  |  3  | 103 |
+   1 |   1  |   0  |      | PSFC     | Pa      | Surface Pressure                        |  0  |  3  |  0  |   1 |
+   2 | 102  |   0  |      | PMSL     | Pa      | Sea-level Pressure                      |  0  |  3  |  1  | 101 |
+   7 |   1  |   0  |      | SOILHGT  | m       | Terrain field of source analysis        |  0  |  3  |  6  |   1 |
+  81 |   1  |   0  |      | LANDSEA  | proprtn | Land/Sea flag (1=land, 0 or 2=sea)      |  2  |  0  |  0  |   1 |
+  11 |   1  |   0  |      | SKINTEMP | K       | Skin temperature                        |  0  |  0  |  0  |   1 |
+  65 |   1  |   0  |      | SNOW     | kg m-2  | Water equivalent snow depth             |  0  |  1  | 60  |   1 |
+  66 |   1  |   0  |      | SNOWH    | m       | Physical Snow Depth                     |  0  |  1  | 11  |   1 |
+  85 | 111  |   5  |      | SOILT001 | K       | Soil Temp  0.5 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |   2  |      | SOILT002 | K       | Soil Temp    2 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |   6  |      | SOILT006 | K       | Soil Temp    6 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |  18  |      | SOILT018 | K       | Soil Temp   18 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |  54  |      | SOILT054 | K       | Soil Temp   54 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  | 162  |      | SOILT162 | K       | Soil Temp  162 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  | 486  |      | SOILT486 | K       | Soil Temp  486 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |1458  |      | SOILT999 | K       | Soil Temp 1458 cm below ground          |  2  |  3  | 18  | 106 |
+  86 | 112  |   0  |   1  | SOILM001 | kg m-2  | Soil Moist      0-1 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |   1  |   3  | SOILM002 | kg m-2  | Soil Moist      1-3 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |   3  |   9  | SOILM006 | kg m-2  | Soil Moist      3-9 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |   9  |  27  | SOILM018 | kg m-2  | Soil Moist     9-27 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |  27  |  81  | SOILM054 | kg m-2  | Soil Moist    27-81 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |  81  | 243  | SOILM162 | kg m-2  | Soil Moist   81-243 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  | 243  | 729  | SOILM486 | kg m-2  | Soil Moist  243-729 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  | 729  | 2187 | SOILM999 | kg m-2  | Soil Moist 729-2187 cm below grn layer  |  2  |  3  | 20  | 106 |
+-----+------+------+------+----------+---------+-----------------------------------------+-----------------------+
+#
+#  Vtable for ICON data on model levels
+#  https://opendata.dwd.de/weather/nwp/icon-eu/grib/
+#  
+# Notes:
+# Variable from server come as individual files per variable and timestep so need to merge them together.
+# Some variable only come for initial time so need to be added for each timestep being ingested into wps.
+#
+# Due to model levels being on .5 levels then need to convert these to whole model levels before running ungrib 
+# Can be done using CDO command (cdo -setzaxis,"zaxis.tmp" Fin Fout) for each variable)

--- a/ungrib/Variable_Tables/Vtable.ICONp
+++ b/ungrib/Variable_Tables/Vtable.ICONp
@@ -1,0 +1,45 @@
+GRIB1| Level| From |  To  | metgrid  | metgrid | metgrid                                 |GRIB2|GRIB2|GRIB2|GRIB2|
+Param| Type |Level1|Level2| Name     | Units   | Description                             |Discp|Catgy|Param|Level|
+-----+------+------+------+----------+---------+-----------------------------------------+-----------------------+
+  11 | 100  |   *  |      | TT       | K       | Temperature                             |  0  |  0  |  0  | 100 |
+  33 | 100  |   *  |      | UU       | m s-1   | U                                       |  0  |  2  |  2  | 100 |
+  34 | 100  |   *  |      | VV       | m s-1   | V                                       |  0  |  2  |  3  | 100 |
+  52 | 100  |   *  |      | RH       | %       | Relative Humidity                       |  0  |  1  |  1  | 100 |
+ 129 | 100  |   *  |      | GEOPT    | m2 s-2  | Geopotential                            |  0  |  3  |  4  | 100 |
+     | 100  |   *  |      | HGT      | m       | Height                                  |     |     |     | 100 |
+  11 | 105  |   2  |      | TT       | K       | Temperature       at 2 m                |  0  |  0  |  0  | 103 |
+  33 | 105  |  10  |      | UU       | m s-1   | U                 at 10 m               |  0  |  2  |  2  | 103 |
+  34 | 105  |  10  |      | VV       | m s-1   | V                 at 10 m               |  0  |  2  |  3  | 103 |
+  52 | 105  |   2  |      | RH       | %       | Relative Humidity at 2 m                |  0  |  1  |  1  | 103 |
+   1 |   1  |   0  |      | PSFC     | Pa      | Surface Pressure                        |  0  |  3  |  0  |   1 |
+   2 | 102  |   0  |      | PMSL     | Pa      | Sea-level Pressure                      |  0  |  3  |  1  | 101 |
+   7 |   1  |   0  |      | SOILHGT  | m       | Terrain field of source analysis        |  0  |  3  |  6  |   1 |
+  81 |   1  |   0  |      | LANDSEA  | proprtn | Land/Sea flag (1=land, 0 or 2=sea)      |  2  |  0  |  0  |   1 |
+  11 |   1  |   0  |      | SKINTEMP | K       | Skin temperature                        |  0  |  0  |  0  |   1 |
+  65 |   1  |   0  |      | SNOW     | kg m-2  | Water equivalent snow depth             |  0  |  1  | 60  |   1 |
+  66 |   1  |   0  |      | SNOWH    | m       | Physical Snow Depth                     |  0  |  1  | 11  |   1 |  
+  85 | 111  |   5  |      | SOILT001 | K       | Soil Temp  0.5 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |   2  |      | SOILT002 | K       | Soil Temp    2 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |   6  |      | SOILT006 | K       | Soil Temp    6 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |  18  |      | SOILT018 | K       | Soil Temp   18 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |  54  |      | SOILT054 | K       | Soil Temp   54 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  | 162  |      | SOILT162 | K       | Soil Temp  162 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  | 486  |      | SOILT486 | K       | Soil Temp  486 cm below ground          |  2  |  3  | 18  | 106 |
+  85 | 111  |1458  |      | SOILT999 | K       | Soil Temp 1458 cm below ground          |  2  |  3  | 18  | 106 |
+  86 | 112  |   0  |   1  | SOILM001 | kg m-2  | Soil Moist      0-1 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |   1  |   3  | SOILM002 | kg m-2  | Soil Moist      1-3 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |   3  |   9  | SOILM006 | kg m-2  | Soil Moist      3-9 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |   9  |  27  | SOILM018 | kg m-2  | Soil Moist     9-27 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |  27  |  81  | SOILM054 | kg m-2  | Soil Moist    27-81 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  |  81  | 243  | SOILM162 | kg m-2  | Soil Moist   81-243 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  | 243  | 729  | SOILM486 | kg m-2  | Soil Moist  243-729 cm below grn layer  |  2  |  3  | 20  | 106 |
+  86 | 112  | 729  | 2187 | SOILM999 | kg m-2  | Soil Moist 729-2187 cm below grn layer  |  2  |  3  | 20  | 106 |
+-----+------+------+------+----------+---------+-----------------------------------------+-----------------------+
+#
+#
+#  Vtable for Icon-EU pressure levels from the dwd server.
+#
+# https://opendata.dwd.de/weather/nwp/
+#
+# Variables from server come as individual files per variable and timestep so need to merge them together.
+# Some variable only come for initial time so need to be added for each timestep being ingested into wps.

--- a/ungrib/src/rd_grib1.F
+++ b/ungrib/src/rd_grib1.F
@@ -217,6 +217,8 @@ SUBROUTINE rd_grib1(IUNIT, gribflnm, level, field, hdate,  &
       map%source = 'ECMWF'
   else if (icenter .eq. 74 .or. icenter .eq. 75 ) then
       map%source = 'UKMO'
+  else if (icenter .eq. 78 .or. icenter .eq. 79 ) then
+      map%source = 'DWD'
   else
     map%source = 'unknown model and orig center'
   end if

--- a/ungrib/src/rd_grib2.F
+++ b/ungrib/src/rd_grib2.F
@@ -326,6 +326,8 @@ C  SET ARGUMENTS
              map%source = 'JMA'
            else if (icenter .eq. 74 .or. icenter .eq. 75 ) then
              map%source = 'UKMO'
+           else if (icenter .eq. 78 .or. icenter .eq. 79 ) then
+             map%source = 'DWD'
            else
              map%source = 'unknown model and orig center'
            end if
@@ -757,7 +759,8 @@ C  SET ARGUMENTS
      &                           (10. ** (-1. * gfld%ipdtmpl(11)))
 		 if ( level .lt. pmin ) cycle MATCH_LOOP
               elseif((gfld%ipdtmpl(10).eq.105).or.
-     &               (gfld%ipdtmpl(10).eq.118))then
+     &               (gfld%ipdtmpl(10).eq.118).or.
+     &               (gfld%ipdtmpl(10).eq.150))then
                  ! Hybrid level (range from 1 to N)
                  level=gfld%ipdtmpl(12)
               elseif(gfld%ipdtmpl(10).eq.104) then

--- a/ungrib/src/rrpr.F
+++ b/ungrib/src/rrpr.F
@@ -790,6 +790,17 @@ subroutine rrpr(hstart, ntimes, interval, nlvl, maxlvl, plvl, &
             endif
        endif
 
+! Convert soil moisture in ICON input from kg m-2 to m3 m-3      
+       if (index(map%source,'DWD') .ne. 0) then
+          if (is_there(200100, 'SOILM001')) then
+           call get_dims(200100, 'SOILM001')
+              print *,'Adjusting ICON soil moisture'
+           call mprintf(.true.,DEBUG, &
+              "RRPR:   Adjusting ICON soil moisture ")
+           call fix_icon_soilm (map%nx, map%ny)           
+          endif
+       endif
+       
 !
 ! Check to see if we need to fill SOILHGT from SOILGEO.
 ! (From Wei Wang, 2007 June 21)
@@ -1410,7 +1421,60 @@ subroutine fix_ruc_soilm (ix, jx)
   deallocate(soilcat)
 
 end subroutine fix_ruc_soilm
- 
+
+subroutine fix_icon_soilm (ix, jx)
+  use storage_module
+  implicit none
+  integer :: ix, jx
+  real, allocatable, dimension(:,:) :: soilm001, soilm002, soilm006, &
+                     soilm018, soilm054, soilm162, soilm486, soilm999
+  allocate(soilm001(ix,jx))
+  allocate(soilm002(ix,jx))
+  allocate(soilm006(ix,jx))
+  allocate(soilm018(ix,jx))
+  allocate(soilm054(ix,jx))
+  allocate(soilm162(ix,jx))
+  allocate(soilm486(ix,jx))
+  allocate(soilm999(ix,jx))
+  call get_storage(200100, 'SOILM001', soilm001, ix, jx)
+  call get_storage(200100, 'SOILM002', soilm002, ix, jx)
+  call get_storage(200100, 'SOILM006', soilm006, ix, jx)
+  call get_storage(200100, 'SOILM018', soilm018, ix, jx)
+  call get_storage(200100, 'SOILM054', soilm054, ix, jx)
+  call get_storage(200100, 'SOILM162', soilm162, ix, jx)
+  call get_storage(200100, 'SOILM486', soilm486, ix, jx)
+  call get_storage(200100, 'SOILM999', soilm999, ix, jx)
+    !convert kg m-2 to m3 m-3
+    soilm001 = soilm001 /  0.01 / 1000.
+    soilm002 = soilm002 /  0.02 / 1000.
+    soilm006 = soilm006 /  0.06 / 1000.
+    soilm018 = soilm018 /  0.18 / 1000.
+    soilm054 = soilm054 /  0.54 / 1000.
+    soilm162 = soilm162 /  1.62 / 1000.
+    soilm486 = soilm486 /  4.86 / 1000.
+    soilm999 = soilm999 / 14.58 / 1000.
+  call put_storage(200100, 'SOILM001', soilm001, ix, jx)
+  call put_storage(200100, 'SOILM002', soilm002, ix, jx)
+  call put_storage(200100, 'SOILM006', soilm006, ix, jx)
+  call put_storage(200100, 'SOILM018', soilm018, ix, jx)
+  call put_storage(200100, 'SOILM054', soilm054, ix, jx)
+  call put_storage(200100, 'SOILM162', soilm162, ix, jx)
+  call put_storage(200100, 'SOILM486', soilm486, ix, jx)
+  call put_storage(200100, 'SOILM999', soilm999, ix, jx)
+
+ print *,'fix_icon_soilm is done!'
+
+  deallocate(soilm001)
+  deallocate(soilm002)
+  deallocate(soilm006)
+  deallocate(soilm018)
+  deallocate(soilm054)
+  deallocate(soilm162)
+  deallocate(soilm486)
+  deallocate(soilm999)
+
+end subroutine fix_icon_soilm
+
 subroutine fix_gefs_landmask (ix, jx, plvl)
 ! Set LANDSEA to values based on soil temp. Assumes fix_gfs_miss has already been called.
 ! Needed for September 23, 2020 changes to GEFS. 


### PR DESCRIPTION
The ICON grib2 data set is now able to be ingested by the ungrib program. Informations about the ICON data set can be found here: https://www.dwd.de/DWD/forschung/nwv/fepub/icon_database_main.pdf

1. Two Vtable files (pressure and model levels) have been created with the fields required by the WRF model. Minor changes have been adapted compared to PR #154 
2. Modifications to the ungrib source code: Adding support for level code 150 in rd_grid2.F because model levels of ICON are on generalized vertical height coordinates. The general vertical height coordinate is not specified by vertical coordinate parameters but by providing a 3D field, that specifies the geometric height of every model grid point in meters. For more details, see Appendix in: https://www.dwd.de/DWD/forschung/nwv/fepub/icon_database_main.pdf
3. Addition of new soil levels: New soil levels from ICON are added to METGRID.TBL.ARW for metgrid.exe. Details about the soil levels in ICON can be found in the documentation (see above). Compared to PR #154 all available model levels (soil moisture and temperature) are included now. 
4. Conversion of soil moisture units to those expected by the WRF model: The preprocessing in rrpr.F has to be modified to convert the units of column-integrated soil moisture provided by ICON from kg m-2 to m3 m-2 for WRF input.
5. Addition of an identifier for DWD models (ICON) in rd_grib2.F and rd_grib1.F as done by @WQadam

This PR has been tested with ICON-EU (~6.6 km resolution) data, but it should be able to run with ICON-D2 (~2.2 km resolution) and ICON-Global. For the latter it needs to be converted from an icosahedral grid to a regular lat-lon grid. Data for testing can be taken from PR #154 

This PR is very similar to PR #220. Nevertheless I published it, so you can decide which one is more appropriate for your needs.

