### PR TITLE
added grib2 table parameter codes according to new ECMWF open data and grib1 geopotential height

### DIFF
--- a/ungrib/Variable_Tables/Vtable.ECMWF
+++ b/ungrib/Variable_Tables/Vtable.ECMWF
@@ -12,7 +12,7 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
  167 |  1   |   0  |      | TT       | K        | Temperature          At  2 m             |  0  |  0  |  0  | 103 |
  168 |  1   |   0  |      | DEWPT    | K        |                                          |  0  |  0  |     | 103 |
      |  1   |   0  |      | RH       | %        | Relative Humidity    At  2 m             |  0  |  0  |     | 103 | 
- 172 |  1   |   0  |      | LANDSEA  | 0/1 Flag | Land/Sea flag                            |  0  |  0  |     | 103 | 
+ 172 |  1   |   0  |      | LANDSEA  | 0/1 Flag | Land/Sea flag                            |  2  |  0  |  0  |  1  | 
  129 |  1   |   0  |      | SOILGEO  | m2 s-2   |                                          |  0  |  0  |     | 103 | 
      |  1   |   0  |      | SOILHGT  | m        | Terrain field of source analysis         |  0  |  0  |     | 106 | 
  134 |  1   |   0  |      | PSFC     | Pa       | Surface Pressure                         |  0  |  3  |  0  |  1  |
@@ -22,14 +22,14 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
   34 |  1   |   0  |      | SST      | K        | Sea-Surface Temperature                  |  0  |  3  |     | 101 |
  141 |  1   |   0  |      | SNOW_EC  | m        |                                          |  0  |  3  |     | 101 |
      |  1   |   0  |      | SNOW     | kg m-2   |Water Equivalent of Accumulated Snow Depth|  0  |  3  |     | 101 |
- 139 | 112  |   0  |   7  | ST000007 | K        | T of 0-7 cm ground layer                 |  0  |  0  |     | 106 | 
- 170 | 112  |   7  |  28  | ST007028 | K        | T of 7-28 cm ground layer                |  0  |  0  |     | 106 | 
- 183 | 112  |  28  | 100  | ST028100 | K        | T of 28-100 cm ground layer              |  0  |  0  |     | 106 | 
- 236 | 112  | 100  | 255  | ST100289 | K        | T of 100-289 cm ground layer             |  0  |  0  |     | 106 | 
-  39 | 112  |   0  |   7  | SM000007 | fraction | Soil moisture of 0-7 cm ground layer     |  0  |  0  |     | 106 | 
-  40 | 112  |   7  |  28  | SM007028 | fraction | Soil moisture of 7-28 cm ground layer    |  0  |  0  |     | 106 | 
-  41 | 112  |  28  | 100  | SM028100 | fraction | Soil moisture of 28-100 cm ground layer  |  0  |  0  |     | 106 | 
-  42 | 112  | 100  | 255  | SM100289 | fraction | Soil moisture of 100-289 cm ground layer |  0  |  0  |     | 106 | 
+ 139 | 112  |   0  |   7  | ST000007 | K        | T of 0-7 cm ground layer                 |  2  |  0  |  2  | 106 | 
+ 170 | 112  |   7  |  28  | ST007028 | K        | T of 7-28 cm ground layer                |  2  |  0  |     | 106 | 
+ 183 | 112  |  28  | 100  | ST028100 | K        | T of 28-100 cm ground layer              |  2  |  0  |     | 106 | 
+ 236 | 112  | 100  | 255  | ST100289 | K        | T of 100-289 cm ground layer             |  2  |  0  |     | 106 | 
+  39 | 112  |   0  |   7  | SM000007 | fraction | Soil moisture of 0-7 cm ground layer     |  2  |  0  |     | 106 | 
+  40 | 112  |   7  |  28  | SM007028 | fraction | Soil moisture of 7-28 cm ground layer    |  2  |  0  |     | 106 | 
+  41 | 112  |  28  | 100  | SM028100 | fraction | Soil moisture of 28-100 cm ground layer  |  2  |  0  |     | 106 | 
+  42 | 112  | 100  | 255  | SM100289 | fraction | Soil moisture of 100-289 cm ground layer |  2  |  0  |     | 106 | 
 -----+------+------+------+----------+----------+------------------------------------------+-----+-----+-----+-----+
 #
 #  Grib codes are from Table 128 

--- a/ungrib/Variable_Tables/Vtable.ECMWF
+++ b/ungrib/Variable_Tables/Vtable.ECMWF
@@ -1,6 +1,6 @@
-GRIB1| Level| From |  To  | metgrid  | metgrid | metgrid                                   |GRIB2|GRIB2|GRIB2|GRIB2|
-Param| Type |Level1|Level2| Name     | Units   | Description                               |Discp|Catgy|Param|Level|
------+------+------+------+----------+---------+-------------------------------------------+-----------------------+
+GRIB1| Level| From |  To  | metgrid  | metgrid  | metgrid                                  |GRIB2|GRIB2|GRIB2|GRIB2|
+Param| Type |Level1|Level2| Name     | Units    | Description                              |Discp|Catgy|Param|Level|
+-----+------+------+------+----------+----------+------------------------------------------+-----------------------+
  129 | 100  |   *  |      | GEOPT    | m2 s-2   |                                          |  0  |  0  |     | 100 |
  156 | 100  |   *  |      | HGT      | m        | Height                                   |  0  |  3  |  5  | 100 |  
  130 | 100  |   *  |      | TT       | K        | Temperature                              |  0  |  0  |  0  | 100 |
@@ -10,7 +10,7 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
  165 |  1   |   0  |      | UU       | m s-1    | U                    At 10 m             |  0  |  2  |  2  | 103 | 
  166 |  1   |   0  |      | VV       | m s-1    | V                    At 10 m             |  0  |  2  |  3  | 103 | 
  167 |  1   |   0  |      | TT       | K        | Temperature          At  2 m             |  0  |  0  |  0  | 103 |
- 168 |  1   |   0  |      | DEWPT    | K        |                                          |  0  |  0  |     | 103 |
+ 168 |  1   |   0  |      | DEWPT    | K        |                                          |  0  |  0  |  6  | 103 |
      |  1   |   0  |      | RH       | %        | Relative Humidity    At  2 m             |  0  |  0  |     | 103 | 
  172 |  1   |   0  |      | LANDSEA  | 0/1 Flag | Land/Sea flag                            |  2  |  0  |  0  |  1  | 
  129 |  1   |   0  |      | SOILGEO  | m2 s-2   |                                          |  0  |  0  |     | 103 | 
@@ -23,13 +23,13 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
  141 |  1   |   0  |      | SNOW_EC  | m        |                                          |  0  |  3  |     | 101 |
      |  1   |   0  |      | SNOW     | kg m-2   |Water Equivalent of Accumulated Snow Depth|  0  |  3  |     | 101 |
  139 | 112  |   0  |   7  | ST000007 | K        | T of 0-7 cm ground layer                 |  2  |  0  |  2  | 106 | 
- 170 | 112  |   7  |  28  | ST007028 | K        | T of 7-28 cm ground layer                |  2  |  0  |     | 106 | 
- 183 | 112  |  28  | 100  | ST028100 | K        | T of 28-100 cm ground layer              |  2  |  0  |     | 106 | 
- 236 | 112  | 100  | 255  | ST100289 | K        | T of 100-289 cm ground layer             |  2  |  0  |     | 106 | 
-  39 | 112  |   0  |   7  | SM000007 | fraction | Soil moisture of 0-7 cm ground layer     |  2  |  0  |     | 106 | 
-  40 | 112  |   7  |  28  | SM007028 | fraction | Soil moisture of 7-28 cm ground layer    |  2  |  0  |     | 106 | 
-  41 | 112  |  28  | 100  | SM028100 | fraction | Soil moisture of 28-100 cm ground layer  |  2  |  0  |     | 106 | 
-  42 | 112  | 100  | 255  | SM100289 | fraction | Soil moisture of 100-289 cm ground layer |  2  |  0  |     | 106 | 
+ 170 | 112  |   7  |  28  | ST007028 | K        | T of 7-28 cm ground layer                | 192 | 128 | 170 | 106 | 
+ 183 | 112  |  28  | 100  | ST028100 | K        | T of 28-100 cm ground layer              | 192 | 128 | 183 | 106 | 
+ 236 | 112  | 100  | 255  | ST100289 | K        | T of 100-289 cm ground layer             | 192 | 128 | 236 | 106 | 
+  39 | 112  |   0  |   7  | SM000007 | fraction | Soil moisture of 0-7 cm ground layer     | 192 | 128 | 39  | 106 | 
+  40 | 112  |   7  |  28  | SM007028 | fraction | Soil moisture of 7-28 cm ground layer    | 192 | 128 | 40  | 106 | 
+  41 | 112  |  28  | 100  | SM028100 | fraction | Soil moisture of 28-100 cm ground layer  | 192 | 128 | 41  | 106 | 
+  42 | 112  | 100  | 255  | SM100289 | fraction | Soil moisture of 100-289 cm ground layer | 192 | 128 | 42  | 106 | 
 -----+------+------+------+----------+----------+------------------------------------------+-----+-----+-----+-----+
 #
 #  Grib codes are from Table 128 

--- a/ungrib/Variable_Tables/Vtable.ECMWF
+++ b/ungrib/Variable_Tables/Vtable.ECMWF
@@ -14,7 +14,7 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
      |  1   |   0  |      | RH       | %        | Relative Humidity    At  2 m             |  0  |  0  |     | 103 | 
  172 |  1   |   0  |      | LANDSEA  | 0/1 Flag | Land/Sea flag                            |  2  |  0  |  0  |  1  | 
  129 |  1   |   0  |      | SOILGEO  | m2 s-2   |                                          |  0  |  0  |     | 103 | 
-     |  1   |   0  |      | SOILHGT  | m        | Terrain field of source analysis         |  0  |  0  |     | 106 | 
+ 156 |  1   |   0  |      | SOILHGT  | m        | Terrain field of source analysis         |  0  |  0  |     | 106 | 
  134 |  1   |   0  |      | PSFC     | Pa       | Surface Pressure                         |  0  |  3  |  0  |  1  |
  151 |  1   |   0  |      | PMSL     | Pa       | Sea-level Pressure                       |  0  |  3  |  0  | 101 |
  235 |  1   |   0  |      | SKINTEMP | K        | Sea-Surface Temperature                  |  0  |  3  |     | 101 |

--- a/ungrib/Variable_Tables/Vtable.ECMWF
+++ b/ungrib/Variable_Tables/Vtable.ECMWF
@@ -1,36 +1,36 @@
-GRIB | Level| Level| Level| metgrid  |  metgrid | metgrid                                  |
-Code | Code |   1  |   2  | Name     |  Units   | Description                              |
------+------+------+------+----------+----------+------------------------------------------+
- 129 | 100  |   *  |      | GEOPT    | m2 s-2   |                                          | 
-     | 100  |   *  |      | HGT      | m        | Height                                   |
- 130 | 100  |   *  |      | TT       | K        | Temperature                              |
- 131 | 100  |   *  |      | UU       | m s-1    | U                                        |
- 132 | 100  |   *  |      | VV       | m s-1    | V                                        |
- 157 | 100  |   *  |      | RH       | %        | Relative Humidity                        |
- 165 |  1   |   0  |      | UU       | m s-1    | U                    At 10 m             | 
- 166 |  1   |   0  |      | VV       | m s-1    | V                    At 10 m             | 
- 167 |  1   |   0  |      | TT       | K        | Temperature          At  2 m             | 
- 168 |  1   |   0  |      | DEWPT    | K        |                                          | 
-     |  1   |   0  |      | RH       | %        | Relative Humidity    At  2 m             | 
- 172 |  1   |   0  |      | LANDSEA  | 0/1 Flag | Land/Sea flag                            |
- 129 |  1   |   0  |      | SOILGEO  | m2 s-2   |                                          |
-     |  1   |   0  |      | SOILHGT  | m        | Terrain field of source analysis         |
- 134 |  1   |   0  |      | PSFC     | Pa       | Surface Pressure                         |
- 151 |  1   |   0  |      | PMSL     | Pa       | Sea-level Pressure                       |
- 235 |  1   |   0  |      | SKINTEMP | K        | Sea-Surface Temperature                  |
-  31 |  1   |   0  |      | SEAICE   | 0/1 Flag | Sea-Ice-Flag                             |
-  34 |  1   |   0  |      | SST      | K        | Sea-Surface Temperature                  |
- 141 |  1   |   0  |      | SNOW_EC  | m        |                                          |
-     |  1   |   0  |      | SNOW     | kg m-2   |Water Equivalent of Accumulated Snow Depth|
- 139 | 112  |   0  |   7  | ST000007 | K        | T of 0-7 cm ground layer                 |
- 170 | 112  |   7  |  28  | ST007028 | K        | T of 7-28 cm ground layer                |
- 183 | 112  |  28  | 100  | ST028100 | K        | T of 28-100 cm ground layer              |
- 236 | 112  | 100  | 255  | ST100289 | K        | T of 100-289 cm ground layer             |
-  39 | 112  |   0  |   7  | SM000007 | fraction | Soil moisture of 0-7 cm ground layer     |
-  40 | 112  |   7  |  28  | SM007028 | fraction | Soil moisture of 7-28 cm ground layer    |
-  41 | 112  |  28  | 100  | SM028100 | fraction | Soil moisture of 28-100 cm ground layer  |
-  42 | 112  | 100  | 255  | SM100289 | fraction | Soil moisture of 100-289 cm ground layer |
------+------+------+------+----------+----------+------------------------------------------+
+GRIB1| Level| From |  To  | metgrid  | metgrid | metgrid                                   |GRIB2|GRIB2|GRIB2|GRIB2|
+Param| Type |Level1|Level2| Name     | Units   | Description                               |Discp|Catgy|Param|Level|
+-----+------+------+------+----------+---------+-------------------------------------------+-----------------------+
+ 129 | 100  |   *  |      | GEOPT    | m2 s-2   |                                          |  0  |  0  |     | 100 |
+ 156 | 100  |   *  |      | HGT      | m        | Height                                   |  0  |  3  |  5  | 100 |  
+ 130 | 100  |   *  |      | TT       | K        | Temperature                              |  0  |  0  |  0  | 100 |
+ 131 | 100  |   *  |      | UU       | m s-1    | U                                        |  0  |  2  |  2  | 100 |
+ 132 | 100  |   *  |      | VV       | m s-1    | V                                        |  0  |  2  |  3  | 100 |
+ 157 | 100  |   *  |      | RH       | %        | Relative Humidity                        |  0  |  1  |  1  | 100 |
+ 165 |  1   |   0  |      | UU       | m s-1    | U                    At 10 m             |  0  |  2  |  2  | 103 | 
+ 166 |  1   |   0  |      | VV       | m s-1    | V                    At 10 m             |  0  |  2  |  3  | 103 | 
+ 167 |  1   |   0  |      | TT       | K        | Temperature          At  2 m             |  0  |  0  |  0  | 103 |
+ 168 |  1   |   0  |      | DEWPT    | K        |                                          |  0  |  0  |     | 103 |
+     |  1   |   0  |      | RH       | %        | Relative Humidity    At  2 m             |  0  |  0  |     | 103 | 
+ 172 |  1   |   0  |      | LANDSEA  | 0/1 Flag | Land/Sea flag                            |  0  |  0  |     | 103 | 
+ 129 |  1   |   0  |      | SOILGEO  | m2 s-2   |                                          |  0  |  0  |     | 103 | 
+     |  1   |   0  |      | SOILHGT  | m        | Terrain field of source analysis         |  0  |  0  |     | 106 | 
+ 134 |  1   |   0  |      | PSFC     | Pa       | Surface Pressure                         |  0  |  3  |  0  |  1  |
+ 151 |  1   |   0  |      | PMSL     | Pa       | Sea-level Pressure                       |  0  |  3  |  0  | 101 |
+ 235 |  1   |   0  |      | SKINTEMP | K        | Sea-Surface Temperature                  |  0  |  3  |     | 101 |
+  31 |  1   |   0  |      | SEAICE   | 0/1 Flag | Sea-Ice-Flag                             |  0  |  3  |     | 101 |
+  34 |  1   |   0  |      | SST      | K        | Sea-Surface Temperature                  |  0  |  3  |     | 101 |
+ 141 |  1   |   0  |      | SNOW_EC  | m        |                                          |  0  |  3  |     | 101 |
+     |  1   |   0  |      | SNOW     | kg m-2   |Water Equivalent of Accumulated Snow Depth|  0  |  3  |     | 101 |
+ 139 | 112  |   0  |   7  | ST000007 | K        | T of 0-7 cm ground layer                 |  0  |  0  |     | 106 | 
+ 170 | 112  |   7  |  28  | ST007028 | K        | T of 7-28 cm ground layer                |  0  |  0  |     | 106 | 
+ 183 | 112  |  28  | 100  | ST028100 | K        | T of 28-100 cm ground layer              |  0  |  0  |     | 106 | 
+ 236 | 112  | 100  | 255  | ST100289 | K        | T of 100-289 cm ground layer             |  0  |  0  |     | 106 | 
+  39 | 112  |   0  |   7  | SM000007 | fraction | Soil moisture of 0-7 cm ground layer     |  0  |  0  |     | 106 | 
+  40 | 112  |   7  |  28  | SM007028 | fraction | Soil moisture of 7-28 cm ground layer    |  0  |  0  |     | 106 | 
+  41 | 112  |  28  | 100  | SM028100 | fraction | Soil moisture of 28-100 cm ground layer  |  0  |  0  |     | 106 | 
+  42 | 112  | 100  | 255  | SM100289 | fraction | Soil moisture of 100-289 cm ground layer |  0  |  0  |     | 106 | 
+-----+------+------+------+----------+----------+------------------------------------------+-----+-----+-----+-----+
 #
 #  Grib codes are from Table 128 
 #  http://old.ecmwf.int/publications/manuals/d/gribapi/param/filter=grib1/order=paramId/order_type=asc/p=1/table=128/


### PR DESCRIPTION
grib2 table parameter codes according to https://data.ecmwf.int/forecasts/ dataset in the link is added.

ECMWF made some of the variables open in 0.4 resolution. But unfortunately, it does not cover all the variables required to run WRF but can be mixed with other datasets.

also, the grib1 param code for geopotential height is added.