### PR TITLE
No need to write GEOPT and SPECHUMD in intermediate file

### DIFF
--- a/ungrib/Variable_Tables/Vtable.ICONm
+++ b/ungrib/Variable_Tables/Vtable.ICONm
@@ -6,9 +6,9 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
   11 | 109  |   *  |      | TT       | K       | Temperature                             |  0  |  0  |  0  | 150 |
   33 | 109  |   *  |      | UU       | m s-1   | U                                       |  0  |  2  |  2  | 150 |
   34 | 109  |   *  |      | VV       | m s-1   | V                                       |  0  |  2  |  3  | 150 |
-  51 | 109  |   *  |      | SPECHUMD | kg kg-1 | Specific Humidity                       |  0  |  1  |  0  | 150 |
+  51 | 109  |   *  |      | SPECHUMD | kg kg-1 |                                         |  0  |  1  |  0  | 150 |
   11 | 105  |   2  |      | TT       | K       | Temperature       at 2 m                |  0  |  0  |  0  | 103 |
-  51 | 105  |   2  |      | SPECHUMD | kg kg-1 | Specific Humidity at 2 m                |  0  |  1  |  0  | 103 |
+  51 | 105  |   2  |      | SPECHUMD | kg kg-1 |                                         |  0  |  1  |  0  | 103 |
   52 | 105  |   2  |      | RH       | %       | Relative Humidity at 2 m                |  0  |  1  |  1  | 103 |
   33 | 105  |  10  |      | UU       | m s-1   | U                 at 10 m               |  0  |  2  |  2  | 103 |
   34 | 105  |  10  |      | VV       | m s-1   | V                 at 10 m               |  0  |  2  |  3  | 103 |

--- a/ungrib/Variable_Tables/Vtable.ICONp
+++ b/ungrib/Variable_Tables/Vtable.ICONp
@@ -5,7 +5,7 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
   33 | 100  |   *  |      | UU       | m s-1   | U                                       |  0  |  2  |  2  | 100 |
   34 | 100  |   *  |      | VV       | m s-1   | V                                       |  0  |  2  |  3  | 100 |
   52 | 100  |   *  |      | RH       | %       | Relative Humidity                       |  0  |  1  |  1  | 100 |
- 129 | 100  |   *  |      | GEOPT    | m2 s-2  | Geopotential                            |  0  |  3  |  4  | 100 |
+ 129 | 100  |   *  |      | GEOPT    | m2 s-2  |                                         |  0  |  3  |  4  | 100 |
      | 100  |   *  |      | HGT      | m       | Height                                  |     |     |     | 100 |
   11 | 105  |   2  |      | TT       | K       | Temperature       at 2 m                |  0  |  0  |  0  | 103 |
   33 | 105  |  10  |      | UU       | m s-1   | U                 at 10 m               |  0  |  2  |  2  | 103 |


### PR DESCRIPTION
In the two newly added Vtables for ICON model and pressure level data, we remove the field that is not needed in the intermediate file. In the Vtable for pressure level data, GEOPT is not needed since HGT is calculated in ungrib. In the Vtable for model level data, the SPECHUMD is no longer needed since RH has been created.