### PR TITLE
Adding support for CMA-GFS in WPS 

### DIFF
--- a/ungrib/Variable_Tables/Vtable.CMA_GFS
+++ b/ungrib/Variable_Tables/Vtable.CMA_GFS
@@ -22,9 +22,7 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
   85 | 112  | 100  | 200  | ST100200 | K       | T 100-200 cm below ground layer (Bottom)|  0  |  0  |  0  | 106 |
   11 |   1  |   0  |      | SKINTEMP | K       | Skin temperature                        |  0  |  0  |  0  |   1 |
    7 |   1  |   0  |      | SOILHGT  | m       | Terrain field of source analysis        |  0  |  3  |  5  |   1 |
-  91 |   1  |   0  |      | SEAICE   | proprtn | Ice flag                                | 10  |  2  |  0  |   1 |
   81 |   1  |   0  |      | LANDSEA  | proprtn | Land/Sea flag (1=land, 0 or 2=sea)      |  2  |  0  |  0  |   1 |
-  81 |   1  |   0  |      | LANDN    | proprtn |                                         |  2  |  0  | 218 |   1 |
   65 |   1  |   0  |      | SNOW     | kg m-2  | Water equivalent snow depth             |  0  |  1  | 13  |   1 |
      |   1  |   0  |      | SNOWH    | m       | Physical Snow Depth                     |  0  |  1  |     |   1 |
   33 |   6  |   0  |      | UMAXW    | m s-1   | U                 at max wind           |  0  |  2  |  2  |   6 |
@@ -40,7 +38,7 @@ Param| Type |Level1|Level2| Name     | Units   | Description                    
    2 |   7  |   0  |      | TTROP    | K       | Temperature at tropopause               |  0  |  0  |  0  |   7 |
    7 |   7  |   0  |      | HGTTROP  | m       | Height of tropopause                    |  0  |  3  |  5  |   7 |
 -----+------+------+------+----------+---------+-----------------------------------------+-----------------------+
-#  This Vtable was created for CMA/CMA_GFS model data from the CMA server.
+#  This Vtable was created for CMA/CMA_GFS model data from the CMA server.(http://cemc.cma.cn/intro.html?idx=1)
 #  The GRAPES_GFS(here in after referred to as CMA_GFS), the new generation of Global/Regional Assimilation and Prediction Enhanced System
 #  which is independently developped by China Meteorological Administration (CMA), has been put into formal operation.
 #  The data was accesed from:http://data.wis.cma.cn/DCPC_WMC_BJ/open/nwp/gmf_gra/thh00/    (note hh at end)

--- a/ungrib/Variable_Tables/Vtable.CMA_GFS
+++ b/ungrib/Variable_Tables/Vtable.CMA_GFS
@@ -1,0 +1,49 @@
+GRIB1| Level| From |  To  | metgrid  | metgrid | metgrid                                 |GRIB2|GRIB2|GRIB2|GRIB2|
+Param| Type |Level1|Level2| Name     | Units   | Description                             |Discp|Catgy|Param|Level|
+-----+------+------+------+----------+---------+-----------------------------------------+-----------------------+
+  11 | 100  |   *  |      | TT       | K       | Temperature                             |  0  |  0  |  0  | 100 |
+  33 | 100  |   *  |      | UU       | m s-1   | U                                       |  0  |  2  |  2  | 100 |
+  34 | 100  |   *  |      | VV       | m s-1   | V                                       |  0  |  2  |  3  | 100 |
+  52 | 100  |   *  |      | RH       | %       | Relative Humidity                       |  0  |  1  |  1  | 100 |
+   7 | 100  |   *  |      | HGT      | m       | Height                                  |  0  |  3  |  5  | 100 |
+  11 | 105  |   2  |      | TT       | K       | Temperature       at 2 m                |  0  |  0  |  0  | 103 |
+  52 | 105  |   2  |      | RH       | %       | Relative Humidity at 2 m                |  0  |  1  |  1  | 103 |
+  33 | 105  |  10  |      | UU       | m s-1   | U                 at 10 m               |  0  |  2  |  2  | 103 |
+  34 | 105  |  10  |      | VV       | m s-1   | V                 at 10 m               |  0  |  2  |  3  | 103 |
+   1 |   1  |   0  |      | PSFC     | Pa      | Surface Pressure                        |  0  |  3  |  0  |   1 |
+   2 | 102  |   0  |      | PMSL     | Pa      | Sea-level Pressure                      |  0  |  3  |  1  | 101 |
+ 144 | 112  |   0  |  10  | SM000010 | fraction| Soil Moist 0-10 cm below grn layer (Up) |  0  |  1  |  0  | 106 |
+ 144 | 112  |  10  |  40  | SM010040 | fraction| Soil Moist 10-40 cm below grn layer     |  0  |  1  |  0  | 106 |
+ 144 | 112  |  40  | 100  | SM040100 | fraction| Soil Moist 40-100 cm below grn layer    |  0  |  1  |  0  | 106 |
+ 144 | 112  | 100  | 200  | SM100200 | fraction| Soil Moist 100-200 cm below gr layer    |  0  |  1  |  0  | 106 |
+  85 | 112  |   0  |  10  | ST000010 | K       | T 0-10 cm below ground layer (Upper)    |  0  |  0  |  0  | 106 |
+  85 | 112  |  10  |  40  | ST010040 | K       | T 10-40 cm below ground layer (Upper)   |  0  |  0  |  0  | 106 |
+  85 | 112  |  40  | 100  | ST040100 | K       | T 40-100 cm below ground layer (Upper)  |  0  |  0  |  0  | 106 |
+  85 | 112  | 100  | 200  | ST100200 | K       | T 100-200 cm below ground layer (Bottom)|  0  |  0  |  0  | 106 |
+  11 |   1  |   0  |      | SKINTEMP | K       | Skin temperature                        |  0  |  0  |  0  |   1 |
+   7 |   1  |   0  |      | SOILHGT  | m       | Terrain field of source analysis        |  0  |  3  |  5  |   1 |
+  91 |   1  |   0  |      | SEAICE   | proprtn | Ice flag                                | 10  |  2  |  0  |   1 |
+  81 |   1  |   0  |      | LANDSEA  | proprtn | Land/Sea flag (1=land, 0 or 2=sea)      |  2  |  0  |  0  |   1 |
+  81 |   1  |   0  |      | LANDN    | proprtn |                                         |  2  |  0  | 218 |   1 |
+  65 |   1  |   0  |      | SNOW     | kg m-2  | Water equivalent snow depth             |  0  |  1  | 13  |   1 |
+     |   1  |   0  |      | SNOWH    | m       | Physical Snow Depth                     |  0  |  1  |     |   1 |
+  33 |   6  |   0  |      | UMAXW    | m s-1   | U                 at max wind           |  0  |  2  |  2  |   6 |
+  34 |   6  |   0  |      | VMAXW    | m s-1   | V                 at max wind           |  0  |  2  |  3  |   6 |
+   2 |   6  |   0  |      | PMAXW    | Pa      | Pressure of max wind level              |  0  |  3  |  0  |   6 |
+     |   6  |   0  |      | PMAXWNN  | Pa      | PMAXW, used for nearest neighbor interp |  0  |  3  |  0  |   6 |
+   2 |   6  |   0  |      | TMAXW    | K       | Temperature at max wind level           |  0  |  0  |  0  |   6 |
+   7 |   6  |   0  |      | HGTMAXW  | m       | Height of max wind level                |  0  |  3  |  5  |   6 |
+  33 |   7  |   0  |      | UTROP    | m s-1   | U                 at tropopause         |  0  |  2  |  2  |   7 |
+  34 |   7  |   0  |      | VTROP    | m s-1   | V                 at tropopause         |  0  |  2  |  3  |   7 |
+   2 |   7  |   0  |      | PTROP    | Pa      | Pressure of tropopause                  |  0  |  3  |  0  |   7 |
+     |   7  |   0  |      | PTROPNN  | Pa      | PTROP, used for nearest neighbor interp |  0  |  3  |  0  |   7 |
+   2 |   7  |   0  |      | TTROP    | K       | Temperature at tropopause               |  0  |  0  |  0  |   7 |
+   7 |   7  |   0  |      | HGTTROP  | m       | Height of tropopause                    |  0  |  3  |  5  |   7 |
+-----+------+------+------+----------+---------+-----------------------------------------+-----------------------+
+#  This Vtable was created for CMA/CMA_GFS model data from the CMA server.
+#  The GRAPES_GFS(here in after referred to as CMA_GFS), the new generation of Global/Regional Assimilation and Prediction Enhanced System
+#  which is independently developped by China Meteorological Administration (CMA), has been put into formal operation.
+#  The data was accesed from:http://data.wis.cma.cn/DCPC_WMC_BJ/open/nwp/gmf_gra/thh00/    (note hh at end)
+#  Developed by Dr. Haiqing SONG from Inner Mongolia Meteorological Service of China Meteorological Administration(CMA).
+#  E-mail:haiqingsong@emails.imau.edu.cn
+#  wgrib2 -var filename.grib2

--- a/ungrib/src/rd_grib2.F
+++ b/ungrib/src/rd_grib2.F
@@ -735,6 +735,7 @@ C  SET ARGUMENTS
                 end if
                 TMP8LOOP: do j = 1, maxvar
                   if ((g2code(4,j) .eq. 106) .and.
+     &               (gfld%ipdtmpl(1) .eq. g2code(2,j)) .and.  !! Added by Dr.Haiqing SONG, 20181201
      &               (gfld%ipdtmpl(2) .eq. g2code(3,j)) .and.
      &               (glevel1 .eq. level1(j)) .and.
      &               ((glevel2 .eq. level2(j)) .or.


### PR DESCRIPTION
The CMA-GFS grib2 datasets is now able to be ingested by the ungrib program. The GRAPES_GFS(here in after referred to as CMA_GFS), the new generation of Global/Regional Assimilation and Prediction Enhanced System which is independently developped by China Meteorological Administration (CMA), has been put into formal operation. So we are committed to solving the problem of WPS correctly handling CMA_GFS forecast data.

one Vtable files(Vtable.CMA_GFS) has been created with the fields required by the WRF model. 
Modifications to the ungrib source code: Adding support for code 738 in rd_grid2.F because model levels of CMA_GFS are on generalized vertical height coordinates. 

The CMA_GFS real time data is here:http://data.wis.cma.cn/DCPC_WMC_BJ/open/nwp/gmf_gra/

I've tested the program with an Intel compiler and it passed without errors. CMA_GFS forecast data were also used to test, the results are normal.