### PR TITLE
Update g2print to accommodate CMA GFS fields. Add a couple of NCEP GF…

### DIFF
--- a/ungrib/src/g2print.F
+++ b/ungrib/src/g2print.F
@@ -480,6 +480,8 @@ end program g2print
              map%source = 'ECMWF'
            else if (icenter .eq. 34) then
              map%source = 'JMA'
+           else if (icenter .eq. 38) then
+             map%source = 'CMA'
            else if (icenter .eq. 74 .or. icenter .eq. 75 ) then
              map%source = 'UKMO'
            else
@@ -902,7 +904,8 @@ end program g2print
              level=gfld%ipdtmpl(12) *  &
                      (10. ** (-1. * gfld%ipdtmpl(11)))
            else if(gfld%ipdtmpl(10).eq.101 .or.&    ! sea level, sfc, or trop
-                gfld%ipdtmpl(10).eq.1 .or. gfld%ipdtmpl(10).eq.7) then 
+                gfld%ipdtmpl(10).eq.1 .or. gfld%ipdtmpl(10).eq.7 .or. &
+                gfld%ipdtmpl(10).eq.8 .or. gfld%ipdtmpl(10).eq.10) then
              level = 0
            else if(gfld%ipdtmpl(10).eq.106) then  ! below ground sfc is in cm in Vtable
              level= 100. * gfld%ipdtmpl(12)*(10.**(-1.*gfld%ipdtmpl(11)))

--- a/ungrib/src/ngl/g2/params.f
+++ b/ungrib/src/ngl/g2/params.f
@@ -40,7 +40,7 @@
 !
 !$$$
 
-      integer,parameter :: MAXPARAM=816
+      integer,parameter :: MAXPARAM=832
 
       type gribparam
           integer :: g1tblver
@@ -884,6 +884,24 @@
        data paramlist(814) /gribparam(2,255,0,6,18,'TCOLWO')/
        data paramlist(815) /gribparam(2,255,0,6,19,'TCOLIO')/
        data paramlist(816) /gribparam(2,255,0,16,201,'RADARVIL')/
+! Added 06/05/24  for NCEP GFS
+       data paramlist(817) /gribparam(2,214,0,1,37,'CPRAT')/
+       data paramlist(818) /gribparam(2,255,10,2,8,'ICETMP')/
+! Added 06/05/24  for CMA GFS
+       data paramlist(819) /gribparam(2,255,2,0,24,'HFLUX')/
+       data paramlist(820) /gribparam(2,255,0,5,5,'NLWRF')/
+       data paramlist(821) /gribparam(2,255,0,4,9,'NSWRF')/
+       data paramlist(822) /gribparam(2,255,0,5,8,'DLWRFCS')/
+       data paramlist(823) /gribparam(2,255,0,4,11,'NSWRFCS')/
+       data paramlist(824) /gribparam(2,255,0,4,53,'USWRFCS')/
+       data paramlist(825) /gribparam(2,255,0,1,64,'TCIWV')/
+       data paramlist(826) /gribparam(2,255,0,1,69,'TCOLW')/
+       data paramlist(827) /gribparam(2,255,0,1,70,'TCOLI')/
+       data paramlist(828) /gribparam(2,255,0,6,22,'CDCC')/
+       data paramlist(829) /gribparam(2,136,0,2,25,'VWSH')/
+       data paramlist(830) /gribparam(2,255,0,1,19,'PTYPE')/
+       data paramlist(831) /gribparam(2,255,0,6,11,'CDCB')/
+       data paramlist(832) /gribparam(2,255,0,6,12,'CDCTOP')/
 
       contains
 


### PR DESCRIPTION
…S fields.

The changes only affect the labelling of fields not their decoding.