### PR TITLE
Revert changes to configure.defaults from commit 48f7904d

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -10,13 +10,9 @@ FC                  = mpifort
 SFC                 = xlf2003_r
 CC                  = mpicc
 SCC                 = xlc_r
-DM_FC               = mpifort
-DM_CC               = mpicc
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -qufmt=be
-F77FLAGS            = $(FORMAT_FIXED) -qufmt=be
-FORMAT_FREE         = -qfree=f90
-FORMAT_FIXED        = -qfixed
+FFLAGS              = -qfree=f90 -qufmt=be
+F77FLAGS            = -qfixed -qufmt=be
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
 CFLAGS              =
@@ -35,13 +31,9 @@ FC                  = mpifort
 SFC                 = pgfortran
 CC                  = mpicc
 SCC                 = pgcc
-DM_FC               = mpifort
-DM_CC               = mpicc
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -byteswapio
-F77FLAGS            = $(FORMAT_FIXED) -byteswapio
-FORMAT_FREE         = -Mfree
-FORMAT_FIXED        = -Mfixed
+FFLAGS              = -Mfree -byteswapio
+F77FLAGS            = -Mfixed -byteswapio
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
 CFLAGS              =
@@ -63,13 +55,9 @@ MPI_LIB             = -L$(BGL_SYS)/lib -lmpich.rts -lmsglayer.rts -lrts.rts -lde
 FC                  = blrts_xlf90
 SFC                 = blrts_xlf90
 CC                  = blrts_xlc
-DM_FC               = blrts_xlf90
-DM_CC               = blrts_xlc
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) $(MPI_INC)
-F77FLAGS            = $(FORMAT_FIXED) $(MPI_INC)
-FORMAT_FREE         = -qfree=f90
-FORMAT_FIXED        = -qfixed
+FFLAGS              = -qfree=f90 $(MPI_INC)
+F77FLAGS            = -qfixed $(MPI_INC)
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = 
 SCC                 = cc
@@ -97,10 +85,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -byteswapio -O
-F77FLAGS            = $(FORMAT_FIXED) -byteswapio -O
-FORMAT_FREE         = -Mfree
-FORMAT_FIXED        = -Mfixed
+FFLAGS              = -Mfree -byteswapio -O
+F77FLAGS            = -Mfixed -byteswapio -O
 FCSUFFIX            =
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
@@ -123,10 +109,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC 
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -convert big_endian
-F77FLAGS            = $(FORMAT_FIXED) -convert big_endian
-FORMAT_FREE         = -FR
-FORMAT_FIXED        = -FI
+FFLAGS              = -FR -convert big_endian
+F77FLAGS            = -FI -convert big_endian
 FCSUFFIX            =
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
@@ -149,10 +133,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC 
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -O -fendian=big
-F77FLAGS            = $(FORMAT_FIXED) -O -fendian=big
-FORMAT_FREE         = -ffree-form
-FORMAT_FIXED        = -ffixed-form
+FFLAGS              = -ffree-form -O -fendian=big
+F77FLAGS            = -ffixed-form -O -fendian=big
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = 
@@ -175,10 +157,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC 
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -O -fconvert=big-endian -frecord-marker=4
-F77FLAGS            = $(FORMAT_FIXED) -O -fconvert=big-endian -frecord-marker=4
-FORMAT_FREE         = -ffree-form
-FORMAT_FIXED        = -ffixed-form
+FFLAGS              = -ffree-form -O -fconvert=big-endian -frecord-marker=4
+F77FLAGS            = -ffixed-form -O -fconvert=big-endian -frecord-marker=4
 FCCOMPAT            = CONFIGURE_COMPAT_FLAGS
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
@@ -201,10 +181,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC 
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -O -fconvert=big-endian -frecord-marker=4
-F77FLAGS            = $(FORMAT_FIXED) -O -fconvert=big-endian -frecord-marker=4
-FORMAT_FREE         = -ffree-form
-FORMAT_FIXED        = -ffixed-form
+FFLAGS              = -ffree-form -O -fconvert=big-endian -frecord-marker=4
+F77FLAGS            = -ffixed-form -O -fconvert=big-endian -frecord-marker=4
 FCCOMPAT            = CONFIGURE_COMPAT_FLAGS
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
@@ -229,10 +207,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC) 
-FFLAGS              = $(FORMAT_FREE) -byteswapio -O
-F77FLAGS            = $(FORMAT_FIXED) -byteswapio -O
-FORMAT_FREE         = -Mfree
-FORMAT_FIXED        = -Mfixed
+FFLAGS              = -Mfree -byteswapio -O
+F77FLAGS            = -Mfixed -byteswapio -O
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = 
@@ -257,10 +233,8 @@ DM_CC               = $(SCC) -I$(MPI_ROOT)/include
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC) 
-FFLAGS              = $(FORMAT_FREE) -byteswapio -O
-F77FLAGS            = $(FORMAT_FIXED) -byteswapio -O
-FORMAT_FREE         = -Mfree
-FORMAT_FIXED        = -Mfixed
+FFLAGS              = -Mfree -byteswapio -O
+F77FLAGS            = -Mfixed -byteswapio -O
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = -L$(MPI_ROOT)/lib -lmpi
@@ -283,10 +257,8 @@ DM_CC               = mpicc -cc=pathcc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -fno-second-underscore -byteswapio -O
-F77FLAGS            = $(FORMAT_FIXED) -byteswapio -fno-second-underscore -O
-FORMAT_FREE         = -freeform
-FORMAT_FIXED        =
+FFLAGS              = -freeform -fno-second-underscore -byteswapio -O
+F77FLAGS            = -byteswapio -fno-second-underscore -O
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = 
@@ -333,10 +305,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -convert big_endian
-F77FLAGS            = $(FORMAT_FIXED) -convert big_endian
-FORMAT_FREE         = -FR
-FORMAT_FIXED        = -FI
+FFLAGS              = -FR -convert big_endian
+F77FLAGS            = -FI -convert big_endian
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = 
@@ -359,10 +329,8 @@ DM_CC               = $(SCC) -I$(MPI_ROOT)/include
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -convert big_endian
-F77FLAGS            = $(FORMAT_FIXED) -convert big_endian
-FORMAT_FREE         = -FR
-FORMAT_FIXED        = -FI
+FFLAGS              = -FR -convert big_endian
+F77FLAGS            = -FI -convert big_endian
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = -L$(MPI_ROOT)/lib -lmpi
@@ -385,10 +353,8 @@ DM_CC               = mpcc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -convert big_endian
-F77FLAGS            = $(FORMAT_FIXED) -convert big_endian
-FORMAT_FREE         = -FR
-FORMAT_FIXED        = -FI
+FFLAGS              = -FR -convert big_endian
+F77FLAGS            = -FI -convert big_endian
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = 
@@ -411,10 +377,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -byteswapio -O2
-F77FLAGS            = $(FORMAT_FIXED) -byteswapio -O2
-FORMAT_FREE         = -Mfree
-FORMAT_FIXED        = -Mfixed
+FFLAGS              = -Mfree -byteswapio -O2
+F77FLAGS            = -Mfixed -byteswapio -O2
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = -g
@@ -438,10 +402,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -byteswapio -O2
-F77FLAGS            = $(FORMAT_FIXED) -byteswapio -O2
-FORMAT_FREE         = -Mfree
-FORMAT_FIXED        = -Mfixed
+FFLAGS              = -Mfree -byteswapio -O2
+F77FLAGS            = -Mfixed -byteswapio -O2
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = -g
@@ -465,10 +427,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -convert big_endian
-F77FLAGS            = $(FORMAT_FIXED) -convert big_endian
-FORMAT_FREE         = -FR
-FORMAT_FIXED        = -FI
+FFLAGS              = -FR -convert big_endian
+F77FLAGS            = -FI -convert big_endian
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = 
@@ -491,10 +451,8 @@ DM_CC               = mpicc -cc=gcc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -g -fendian=big
-F77FLAGS            = $(FORMAT_FIXED) -g -fendian=big
-FORMAT_FREE         = -ffree-form
-FORMAT_FIXED        = -ffixed-form
+FFLAGS              = -ffree-form -g -fendian=big
+F77FLAGS            = -ffixed-form -g -fendian=big
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = -g
@@ -518,10 +476,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -O -fconvert=big-endian -frecord-marker=4
-F77FLAGS            = $(FORMAT_FIXED) -O -fconvert=big-endian -frecord-marker=4
-FORMAT_FREE         = -ffree-form
-FORMAT_FIXED        = -ffixed-form
+FFLAGS              = -ffree-form -O -fconvert=big-endian -frecord-marker=4
+F77FLAGS            = -ffixed-form -O -fconvert=big-endian -frecord-marker=4
 FCCOMPAT            = CONFIGURE_COMPAT_FLAGS
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
@@ -546,10 +502,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -O -fconvert=big-endian -frecord-marker=4
-F77FLAGS            = $(FORMAT_FIXED) -O -fconvert=big-endian -frecord-marker=4
-FORMAT_FREE         = -ffree-form
-FORMAT_FIXED        = -ffixed-form
+FFLAGS              = -ffree-form -O -fconvert=big-endian -frecord-marker=4
+F77FLAGS            = -ffixed-form -O -fconvert=big-endian -frecord-marker=4
 FCCOMPAT            = CONFIGURE_COMPAT_FLAGS
 FCSUFFIX            =
 FNGFLAGS            = $(FFLAGS)
@@ -579,10 +533,8 @@ DM_CC               = mpicc -cc=$(SCC)
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE)
-F77FLAGS            = $(FORMAT_FIXED)
-FORMAT_FREE         = -qfree
-FORMAT_FIXED        = -qfixed
+FFLAGS              = -qfree
+F77FLAGS            = -qfixed
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS) -qextname
 LDFLAGS             = -Wl,-stack_size,10000000,-stack_addr,0xc000000
@@ -607,10 +559,8 @@ SFC                 = xlf90_r
 SCC                 = gcc-3.3
 DM_FC               = mpif90 -f90=$(SFC)
 DM_CC               = mpicc -cc=$(SCC)
-FFLAGS              = $(FORMAT_FREE)
-F77FLAGS            = $(FORMAT_FIXED)
-FORMAT_FREE         = -qfree
-FORMAT_FIXED        = -qfixed
+FFLAGS              = -qfree
+F77FLAGS            = -qfixed
 FNGFLAGS            = $(FFLAGS) -qextname
 LDFLAGS             = -Wl,-stack_size,10000000,-stack_addr,0xc0000000 -L/usr/lib -lSystemStubs
 FC                  = CONFIGURE_FC
@@ -633,10 +583,8 @@ DM_CC               = mpicc -cc=gcc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -g -fno-second-underscore
-F77FLAGS            = $(FORMAT_FIXED) -g -fno-second-underscore
-FORMAT_FREE         = -ffree-form
-FORMAT_FIXED        = -ffixed-form
+FFLAGS              = -ffree-form -g -fno-second-underscore
+F77FLAGS            = -ffixed-form -g -fno-second-underscore
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = -g
@@ -648,7 +596,7 @@ RANLIB              = ranlib
 CC_TOOLS            =
 
 ########################################################################################################################
-#ARCH    AIX something      # serial serial_NO_GRIB2 dmpar dmpar_NO_GRIB2
+#ARCH    AIX      # serial serial_NO_GRIB2 dmpar dmpar_NO_GRIB2
 #
 COMPRESSION_LIBS    = CONFIGURE_COMP_L
 COMPRESSION_INC     = CONFIGURE_COMP_I
@@ -664,10 +612,8 @@ FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
 AR                  = ar
-FFLAGS              = $(FORMAT_FREE)
-F77FLAGS            = $(FORMAT_FIXED)
-FORMAT_FREE         = -qfree=f90
-FORMAT_FIXED        = -qfixed
+FFLAGS              = -qfree=f90
+F77FLAGS            = -qfixed
 FCSUFFIX            = -qsuffix=f=f90
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
@@ -689,10 +635,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_FC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -convert big_endian
-F77FLAGS            = $(FORMAT_FIXED) -convert big_endian
-FORMAT_FREE         = -free
-FORMAT_FIXED        =
+FFLAGS              = -free -convert big_endian
+F77FLAGS            = -convert big_endian
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =    
 CFLAGS              =    
@@ -713,10 +657,8 @@ DM_CC               = mpicc -cc=$(SCC)
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -g -fno-second-underscore
-F77FLAGS            = $(FORMAT_FIXED) -g -fno-second-underscore
-FORMAT_FREE         = -ffree-form
-FORMAT_FIXED        = -ffixed-form
+FFLAGS              = -ffree-form -g -fno-second-underscore
+F77FLAGS            = -ffixed-form -g -fno-second-underscore
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = -g
@@ -745,10 +687,8 @@ DM_CC               = pgcc -Mmpi=msmpi
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -g
-F77FLAGS            = $(FORMAT_FIXED) -g
-FORMAT_FREE         = -Mfree
-FORMAT_FIXED        = -Mfixed
+FFLAGS              = -Mfree -g
+F77FLAGS            = -Mfixed -g
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = -g
@@ -770,10 +710,8 @@ DM_CC               = mpicc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -64
-F77FLAGS            = $(FORMAT_FIXED) -64
-FORMAT_FREE         = -freeform
-FORMAT_FIXED        =
+FFLAGS              = -freeform -64
+F77FLAGS            = -64
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = -64
@@ -802,10 +740,8 @@ DM_CC               = icc -lmpi
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -convert big_endian
-F77FLAGS            = $(FORMAT_FIXED) -convert big_endian
-FORMAT_FREE         = -FR
-FORMAT_FIXED        = -FI
+FFLAGS              = -FR -convert big_endian
+F77FLAGS            = -FI -convert big_endian
 FCSUFFIX            = 
 FNGFLAGS            = 
 LDFLAGS             = 
@@ -828,10 +764,8 @@ DM_CC               =
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE)
-F77FLAGS            = $(FORMAT_FIXED)
-FORMAT_FREE         = -free
-FORMAT_FIXED        =
+FFLAGS              = -free
+F77FLAGS            = 
 FCSUFFIX            = 
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             = 
@@ -853,10 +787,8 @@ DM_CC               = cc
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -N255 -h byteswapio
-F77FLAGS            = $(FORMAT_FIXED) -N255 -h byteswapio
-FORMAT_FREE         = -f free
-FORMAT_FIXED        = -f fixed
+FFLAGS              = -N255 -f free -h byteswapio
+F77FLAGS            = -N255 -f fixed -h byteswapio
 FCSUFFIX            =
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
@@ -879,10 +811,8 @@ DM_CC               = $(SCC)
 FC                  = CONFIGURE_FC
 CC                  = CONFIGURE_CC
 LD                  = $(FC)
-FFLAGS              = $(FORMAT_FREE) -convert big_endian
-F77FLAGS            = $(FORMAT_FIXED) -convert big_endian
-FORMAT_FREE         = -FR
-FORMAT_FIXED        = -FI
+FFLAGS              = -FR -convert big_endian
+F77FLAGS            = -FI -convert big_endian
 FCSUFFIX            =
 FNGFLAGS            = $(FFLAGS)
 LDFLAGS             =
@@ -915,10 +845,8 @@ CC_TOOLS            =
 #TRADFLAG           = 
 #CPP                = 
 #AR                 = 
-#FFLAGS             = $(FORMAT_FREE)
-#F77FLAGS           = $(FORMAT_FIXED)
-FORMAT_FREE         =
-FORMAT_FIXED        =
+#FFLAGS             = 
+#F77FLAGS           = 
 #FCSUFFIX           = 
 #FNGFLAGS           = 
 #LDFLAGS            = 


### PR DESCRIPTION
This PR reverts changes to `configure.defaults` from commit 48f7904d.

The reorganization in `configure.defaults` from commit 48f7904d breaks compilation with the classic build system (`configure`/`compile`/`clean`) with GNU compilers.

In the `configure` script, logic to determine whether we need to add `-fallow-argument-mismatch` relies on the extraction of the verbatim value of `FFLAGS` for use in compiling a test program. Commit 48f7904d introduced Make variables into `FFLAGS` and these variables aren't expanded when extracting `FFLAGS` in the configure script, leading to an invalid set of compiler flags for the `gnu_flag_test.F90` test program.