### PR TITLE
When extracting FFLAGS in configure script, expand $(FORMAT_FREE) Make variable

### DIFF
--- a/configure
+++ b/configure
@@ -427,6 +427,8 @@ cat > fort_netcdf.f <<EOF
         end program
 EOF
     FFLAGS=`grep ^FFLAGS configure.wps | cut -d"=" -f2-`
+    FORMAT_FREE=`grep ^FORMAT_FREE configure.wps | cut -d"=" -f2-`
+    FFLAGS=`printf "%s" "${FFLAGS}" | sed -e "s/\\$(FORMAT_FREE)/${FORMAT_FREE}/g"`
     cp $NETCDF/include/netcdf.inc .
     FC=`grep ^SFC configure.wps | cut -d"=" -f2-`
     $FC ${FFLAGS} fort_netcdf.f -o fort_netcdf -L${NETCDF}/lib $NETCDFF -lnetcdf > /dev/null 2>&1 
@@ -523,6 +525,8 @@ EOF
 
 FC=`grep ^SFC configure.wps | cut -d"=" -f2-`
 FFLAGS=`grep ^FFLAGS configure.wps | cut -d"=" -f2-`
+FORMAT_FREE=`grep ^FORMAT_FREE configure.wps | cut -d"=" -f2-`
+FFLAGS=`printf "%s" "${FFLAGS}" | sed -e "s/\\$(FORMAT_FREE)/${FORMAT_FREE}/g"`
 $FC ${FFLAGS} gnu_flag_test.F90 -o gnu_flag_test > /dev/null 2>&1
 if [ -f ./gnu_flag_test ]; then
    ./gnu_flag_test > /dev/null 2>&1


### PR DESCRIPTION
This PR adds logic to expand the `$(FORMAT_FREE)` Make variable when extracting `FFLAGS` from the `configure.wps` file in the `configure` script.

With commit 48f7904d, Fortran free-format flags were moved from `FFLAGS` into a separate Make variable named `FORMAT_FREE` in the `arch/configure.defaults` file. Because the `configure` script extracts `FFLAGS` from the `configure.wps` file when compiling test programs, the `$(FORMAT_FREE)` variable is not expanded, leading to compilation errors for test programs.

This PR introduces extra logic in the configure script to expand `$(FORMAT_FREE)` in the `FFLAGS` string for the specification of the `FORMAT_FREE` variable in the `configure.wps` file, allowing for a full set of valid compiler flags to be used when compiling test programs.

Note: If `FORMAT_FREE` itself contains Make variables, these will not be recursively expanded. Also, `$(FORMAT_FREE)` is the only Make variable that is expanded in `FFLAGS` at present.