### PR TITLE
Add aarch64 config defaults

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -930,3 +930,31 @@ FORMAT_FIXED        =
 #ARFLAGS            =
 #RANLIB              = 
 #CC_TOOLS            = 
+
+########################################################################################################################
+#ARCH    Linux aarch64, GNU compilers    # serial serial_NO_GRIB2 dmpar dmpar_NO_GRIB2
+#
+COMPRESSION_LIBS    = CONFIGURE_COMP_L
+COMPRESSION_INC     = CONFIGURE_COMP_I
+FDEFS               = CONFIGURE_FDEFS
+SFC                 = gfortran
+SCC                 = gcc
+DM_FC               = mpif90
+DM_CC               = mpicc
+FC                  = CONFIGURE_FC
+CC                  = CONFIGURE_CC
+LD                  = $(FC)
+FFLAGS              = $(FORMAT_FREE) -O -fconvert=big-endian -frecord-marker=4
+F77FLAGS            = $(FORMAT_FIXED) -O -fconvert=big-endian -frecord-marker=4
+FORMAT_FREE         = -ffree-form
+FORMAT_FIXED        = -ffixed-form
+FCCOMPAT            = CONFIGURE_COMPAT_FLAGS
+FCSUFFIX            = 
+FNGFLAGS            = $(FFLAGS)
+LDFLAGS             =
+CFLAGS              =
+CPP                 = /usr/bin/cpp -P -traditional
+CPPFLAGS            = -D_UNDERSCORE -DBYTESWAP -DLINUX -DIO_NETCDF -DBIT32 -DNO_SIGNAL CONFIGURE_MPI
+ARFLAGS             =
+RANLIB              = ranlib
+CC_TOOLS            =

--- a/ungrib/Variable_Tables/Vtable.ECMWF_sigma
+++ b/ungrib/Variable_Tables/Vtable.ECMWF_sigma
@@ -1,41 +1,42 @@
-GRIB | Level| Level| Level| metgrid  |  metgrid | metgrid                                  |
-Code | Code |   1  |   2  | Name     |  Units   | Description                              |
------+------+------+------+----------+----------+------------------------------------------+
- 130 | 109  |   *  |      | TT       | K        | Temperature                              |
- 131 | 109  |   *  |      | UU       | m s-1    | U                                        |
- 132 | 109  |   *  |      | VV       | m s-1    | V                                        |
- 133 | 109  |   *  |      | SPECHUMD | kg kg-1  | Specific humidity                        |
- 152 | 109  |   *  |      | LOGSFP   | Pa       | Log surface pressure                     |
- 129 |  1   |   0  |      | SOILGEO  | m        |                                          |
-     |  1   |   0  |      | SOILHGT  | m        | Terrain field of source analysis         |
- 165 |  1   |   0  |      | UU       | m s-1    | U                                        | At 10 m
- 166 |  1   |   0  |      | VV       | m s-1    | V                                        | At 10 m
- 167 |  1   |   0  |      | TT       | K        | Temperature                              | At 2 m
- 168 |  1   |   0  |      | DEWPT    | K        |                                          | At 2 m
-     |  1   |   0  |      | RH       | %        | Relative Humidity at 2 m                 | At 2 m
- 172 |  1   |   0  |      | LANDSEA  | 0/1 Flag | Land/Sea flag                            |
- 134 |  1   |   0  |      | PSFC     | Pa       | Surface Pressure                         |
- 134 | 109  |   1  |      | PSFCH    | Pa       |                                          |
- 151 |  1   |   0  |      | PMSL     | Pa       | Sea-level Pressure                       |
- 235 |  1   |   0  |      | SKINTEMP | K        | Sea-Surface Temperature                  |
-  31 |  1   |   0  |      | SEAICE   | 0/1 Flag | Sea-Ice-Flag                             |
-  34 |  1   |   0  |      | SST      | K        | Sea-Surface Temperature                  |
- 141 |  1   |   0  |      | SNOW_EC  | m        |                                          |
-     |  1   |   0  |      | SNOW     | kg m-2   |Water Equivalent of Accumulated Snow Depth|
- 139 | 112  |   0  |   7  | ST000007 | K        | T of 0-7 cm ground layer                 |
- 170 | 112  |   7  |  28  | ST007028 | K        | T of 7-28 cm ground layer                |
- 183 | 112  |  28  | 100  | ST028100 | K        | T of 28-100 cm ground layer              |
- 236 | 112  | 100  | 255  | ST100289 | K        | T of 100-289 cm ground layer             |
-  39 | 112  |   0  |   7  | SM000007 | fraction | Soil moisture of 0-7 cm ground layer     |
-  40 | 112  |   7  |  28  | SM007028 | fraction | Soil moisture of 7-28 cm ground layer    |
-  41 | 112  |  28  | 100  | SM028100 | fraction | Soil moisture of 28-100 cm ground layer  |
-  42 | 112  | 100  | 255  | SM100289 | fraction | Soil moisture of 100-289 cm ground layer |
------+------+------+------+----------+----------+------------------------------------------+
+GRIB1| Level| From |  To  | metgrid  | metgrid  | metgrid                                  |GRIB2|GRIB2|GRIB2|GRIB2|
+Param| Type |Level1|Level2| Name     | Units    | Description                              |Discp|Catgy|Param|Level|
+-----+------+------+------+----------+----------+------------------------------------------+-----------------------+
+ 129 | 105  |   *  |      | GEOPT    | m2 s-2   |                                          |  0  |  3  |  4  | 105 |
+ 156 | 105  |   *  |      | HGT      | m        | Height                                   |  0  |  3  |  5  | 105 |  
+ 130 | 105  |   *  |      | TT       | K        | Temperature                              |  0  |  0  |  0  | 105 |
+ 131 | 105  |   *  |      | UU       | m s-1    | U                                        |  0  |  2  |  2  | 105 |
+ 132 | 105  |   *  |      | VV       | m s-1    | V                                        |  0  |  2  |  3  | 105 |
+ 133 | 105  |   *  |      | SPECHUMD | kg kg-1  | Specific Humidity                        |  0  |  1  |  0  | 105 |
+ 165 |  1   |   0  |      | UU       | m s-1    | U                    At 10 m             |  0  |  2  |  2  | 103 | 
+ 166 |  1   |   0  |      | VV       | m s-1    | V                    At 10 m             |  0  |  2  |  3  | 103 | 
+ 167 |  1   |   0  |      | TT       | K        | Temperature          At  2 m             |  0  |  0  |  0  | 103 |
+ 168 |  1   |   0  |      | DEWPT    | K        |                                          |  0  |  0  |  6  | 103 |
+     |  1   |   0  |      | RH       | %        | Relative Humidity    At  2 m             |  0  |  0  |     | 103 | 
+ 172 |  1   |   0  |      | LANDSEA  | 0/1 Flag | Land/Sea flag                            |  2  |  0  |  0  |  1  | 
+ 129 |  1   |   0  |      | SOILGEO  | m2 s-2   |                                          |  0  |  0  |     | 103 | 
+ 156 |  1   |   0  |      | SOILHGT  | m        | Terrain field of source analysis         |  0  |  0  |     | 106 | 
+ 134 |  1   |   0  |      | PSFC     | Pa       | Surface Pressure                         |  0  |  3  |  0  |  1  |
+ 151 |  1   |   0  |      | PMSL     | Pa       | Sea-level Pressure                       |  0  |  3  |  0  | 101 |
+ 235 |  1   |   0  |      | SKINTEMP | K        | Sea-Surface Temperature                  |  0  |  3  |     | 101 |
+  31 |  1   |   0  |      | SEAICE   | 0/1 Flag | Sea-Ice-Flag                             |  0  |  3  |     | 101 |
+  34 |  1   |   0  |      | SST      | K        | Sea-Surface Temperature                  |  0  |  3  |     | 101 |
+ 141 |  1   |   0  |      | SNOW_EC  | m        |                                          |  0  |  3  |     | 101 |
+     |  1   |   0  |      | SNOW     | kg m-2   |Water Equivalent of Accumulated Snow Depth|  0  |  3  |     | 101 |
+ 139 | 112  |   0  |   7  | ST000007 | K        | T of 0-7 cm ground layer                 |  2  |  0  |  2  | 106 | 
+ 170 | 112  |   7  |  28  | ST007028 | K        | T of 7-28 cm ground layer                | 192 | 128 | 170 | 106 | 
+ 183 | 112  |  28  | 100  | ST028100 | K        | T of 28-100 cm ground layer              | 192 | 128 | 183 | 106 | 
+ 236 | 112  | 100  | 255  | ST100289 | K        | T of 100-289 cm ground layer             | 192 | 128 | 236 | 106 | 
+  39 | 112  |   0  |   7  | SM000007 | fraction | Soil moisture of 0-7 cm ground layer     | 192 | 128 | 39  | 106 | 
+  40 | 112  |   7  |  28  | SM007028 | fraction | Soil moisture of 7-28 cm ground layer    | 192 | 128 | 40  | 106 | 
+  41 | 112  |  28  | 100  | SM028100 | fraction | Soil moisture of 28-100 cm ground layer  | 192 | 128 | 41  | 106 | 
+  42 | 112  | 100  | 255  | SM100289 | fraction | Soil moisture of 100-289 cm ground layer | 192 | 128 | 42  | 106 | 
+-----+------+------+------+----------+----------+------------------------------------------+-----+-----+-----+-----+
 #
-#  In ECMWF hybrid-level files surface pressure can either be at the surface or 
-#  hybrid level 1.
-#
-#  Grib codes are from Table 128
-#  http://www.ecmwf.int/products/data/technical/GRIB_tables/table_128.html
+#  Grib codes are from Table 128 
+#  http://old.ecmwf.int/publications/manuals/d/gribapi/param/filter=grib1/order=paramId/order_type=asc/p=1/table=128/
 #  
-# snow depth is converted to the proper units in rrpr.F
+#  snow depth is converted to the proper units in rrpr.F
+#
+#  Tested on NCAR/RDA ds113.0 dataset. http://rda.ucar.edu/datasets/ds113.0/
+#  Note that for ds113.0 there is one surface data file per day and 4 pressure-level files per day.
+


### PR DESCRIPTION
Add Linux aarch64 GNU compiler architecture to WPS

This PR adds support for Linux aarch64 systems using GNU compilers (gfortran/gcc) to the WPS configure.defaults file. The new architecture definition enables building WPS on ARM64-based Linux systems, supporting both serial and distributed memory parallel (dmpar) configurations, with and without GRIB2 support.

Key features:
- Uses gfortran and gcc compilers
- Configures appropriate flags for big-endian conversion and record markers
- Supports both serial and parallel builds
- Compatible with existing WPS configuration process