### PR TITLE
Only adjust GFS RH in rrpr prior to V16 (3/22/21)

### DIFF
--- a/ungrib/src/rrpr.F
+++ b/ungrib/src/rrpr.F
@@ -587,8 +587,11 @@ subroutine rrpr(hstart, ntimes, interval, nlvl, maxlvl, plvl, &
         endif
 
 ! Repair GFS and ECMWF pressure-level RH
-        if (index(map%source,'NCEP GFS') .ne. 0 .or.  &
-            index(map%source,'NCEP GEFS') .ne. 0 .or. &
+! NCEP switched to rh wrt water with V16 on 3/22/21. 
+
+        if ( ((index(map%source,'NCEP GFS') .ne. 0 .or.  &
+            index(map%source,'NCEP GEFS') .ne. 0) .and. &
+	    (hdate .lt. '2021-03-22_12:00:00')) .or. &
             index(map%source,'NCEP CDAS CFSV2') .ne. 0 .or.  &
             index(map%source,'ECMWF') .ne. 0 ) then
           call mprintf(.true.,DEBUG, &


### PR DESCRIPTION
NCEP changed the GFS RH output in V16 to be with respect to water rather than a function of ice and water, so we no longer need to adjust its RH in ungrib. This GFS change occurred on March 22, 2021 and there was no mention of it (or the UPP) in the Service Change Notice for V16. Tests of the modified rrpr show it correctly processes the V16 RH.  Without this mod, the humidity at temperatures below 0 C is too low. GEFS output was also tested and included in this mod. 