### PR TITLE
CMake Fix MPI Option Selection

### DIFF
--- a/arch/configure_reader.py
+++ b/arch/configure_reader.py
@@ -583,12 +583,12 @@ def projectSpecificOptions( options, stanzaCfg ) :
 
   ##############################################################################
   # Decompose the weird way to write the logic for DM/SM 
-  USE_MPI = False
+  useMPI = False
   if ( stanzaCfg.serialOpt_ or stanzaCfg.smparOpt_ ) and ( stanzaCfg.dmparOpt_ or stanzaCfg.dmsmOpt_ ) :
     # togglable
     # we can safely check this since the user would not have been able to select this stanza if it couldn't be disabled
     if stanzaCfg.dmCompilersAvailable() :
-      useMPI       = not( input( "[DM]    Use MPI?    Default [N] [y/N] : " ).lower() in yesValues )
+      useMPI       = input( "[DM]    Use MPI?    Default [N] [y/N] : " ).lower() in yesValues
     else :
       useMPI = False
   else:


### PR DESCRIPTION
The current logic is flipped to incorrectly negate user requested configuration. The default `[y/N]` prompt is already satisfied by the need to look for explicit `yesValues` matches, otherwise anything else (default) is `False`.

A minor fix is included for the default initial value of the `useMPI` variable. This has no practical effect, but is a cleanup of poor code style relying on variable scope outside of the if-statement.