### PR TITLE
CMake Fix missing MPI preprocessor definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ if ( ${USE_MPI} )
   add_compile_definitions(
                           USE_MPI=1
                           DM_PARALLEL
+                          _MPI
                           )
 
   if ( DEFINED WRF_MPI_Fortran_FLAGS AND NOT "${WRF_MPI_Fortran_FLAGS}" STREQUAL "" )


### PR DESCRIPTION
The preprocessor definition `_MPI` is used to compile WPS with distributed memory capabilities. This define is missing from the set applied when `USE_MPI` is selected in the CMake build. This will result in serial-like behavior even when all the MPI libraries and includes are being used properly during compilation.

This PR adds the `_MPI` compile definition to the set of MPI-specific definitions in the CMake build.