### PR TITLE
CMake Fix ungrib logfile now being named logfile.log  

### DIFF
--- a/ungrib/CMakeLists.txt
+++ b/ungrib/CMakeLists.txt
@@ -6,35 +6,12 @@ add_library   ( pgu )
 add_subdirectory( src )
 
 set_target_properties( 
-                      pgu
+                      ungrib g1print g2print pgu
                       PROPERTIES
                         # Just dump everything in here
                         Fortran_MODULE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/modules/ungrib/
                         Fortran_FORMAT           FREE
-                      )
-
-set_target_properties( 
-                      ungrib
-                      PROPERTIES
-                        # Just dump everything in here
-                        Fortran_MODULE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/modules/ungrib/
-                        Fortran_FORMAT           FREE
-                      )
-
-set_target_properties( 
-                      g1print
-                      PROPERTIES
-                        # Just dump everything in here
-                        Fortran_MODULE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/modules/ungrib/
-                        Fortran_FORMAT           FREE
-                      )
-
-set_target_properties( 
-                      g2print
-                      PROPERTIES
-                        # Just dump everything in here
-                        Fortran_MODULE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/modules/ungrib/
-                        Fortran_FORMAT           FREE
+                        COMPILE_DEFINITIONS      _UNGRIB
                       )
 
 # Control dependencies and linking


### PR DESCRIPTION
The ungrib targets in  the CMake build are missing the `_UNGRIB` define, analogous to the `_METGRID` and `_GEOGRID` defines found elsewhere in the code. 

This PR adds the `_UNGRIB` definition to all WPS-specific targets of ungrib, thereby restoring this expected behavior