### PR TITLE
Change glevel 1 and 2 to ints to prevent floating point equality checks

### DIFF
--- a/ungrib/src/rd_grib2.F
+++ b/ungrib/src/rd_grib2.F
@@ -74,7 +74,7 @@
       real , dimension(maxlvl) :: plvl
       integer :: nlvl
       integer , dimension(maxlvl) :: level_array
-      real :: glevel1, glevel2
+      integer :: glevel1, glevel2
       logical :: first = .true.
       real :: pmin
 


### PR DESCRIPTION
All comparisons to glevel1 and glevel2 are against integer values, relying on implicit conversion during the check if done somewhat correctly. When implicit conversion is not done, the floating point to integer .eq. check can easily fail for values that should normally succeed.

Whilst the calculations to generate glevel1 and glevel2 use floating point math, assigning into an integer variable guarantees a float to int conversion is done before the comparison, thus preventing instances where instead of float to int compilers may other arithmetic operations for comparison such as int to float.