### PR TITLE
Add default values to controllable cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,11 @@ include( wrf_case_setup )
 wrf_get_version( ${PROJECT_SOURCE_DIR}/README )
 
 # Disable WRF-specifics entirely
-set( USE_WRF      ON CACHE BOOL "USE_WRF"     )
+set( USE_WRF          ON CACHE BOOL "USE_WRF"         )
+set( USE_DOUBLE      OFF CACHE BOOL "USE_DOUBLE"      )
+set( USE_MPI         OFF CACHE BOOL "USE_MPI"         )
+set( BUILD_EXTERNALS OFF CACHE BOOL "BUILD_EXTERNALS" )
+
 
 ################################################################################
 ##


### PR DESCRIPTION
The default options are useful when completely bypassing the configuration prompts. Without these default options certain comparison operators are left evaluating blank expansions that would otherwise lead to malformed syntax