### PR TITLE
Add WPS new data for global 1-km urban parameters (Liao et al 2025)

### DIFF
--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -448,6 +448,16 @@ name=URB_PARAM
         rel_path=default:NUDAPT44_1km/
         flag_in_output=FLAG_URB_PARAM
 ===============================
+name=URB_PARAM
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        z_dim_name=num_urb_params
+        interp_option=default: average_gcell(2.0)+nearest_neighbor
+        rel_path=default:gloucp2020_30s/
+        flag_in_output=FLAG_URB_PARAM
+===============================
 name=FRC_URB2D
         priority=1
         optional=yes
@@ -455,6 +465,15 @@ name=FRC_URB2D
         fill_missing = 0.
         interp_option=default: average_gcell(2.0)+four_pt
         rel_path=default:urbfrac_nlcd2011/
+        flag_in_output=FLAG_FRC_URB2D
+===============================
+name=FRC_URB2D
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        interp_option=default: average_gcell(2.0)+four_pt
+        rel_path=default:urbfrac_gaia2020_30s/
         flag_in_output=FLAG_FRC_URB2D
 ===============================
 name=IMPERV
@@ -465,6 +484,16 @@ name=IMPERV
         masked=water
         fill_missing=0.
         rel_path = default:nlcd2011_imp_ll_9s/
+        flag_in_output=FLAG_IMPERV
+===============================
+name=IMPERV
+        priority=2
+        optional=yes
+        dest_type=continuous
+        interp_option = default:average_gcell(2.0)+four_pt
+        masked=water
+        fill_missing=0.
+        rel_path=default:urbfrac_gaia2020_30s/
         flag_in_output=FLAG_IMPERV
 ===============================
 name=CANFRA

--- a/geogrid/GEOGRID.TBL.ARW
+++ b/geogrid/GEOGRID.TBL.ARW
@@ -493,7 +493,7 @@ name=IMPERV
         interp_option = default:average_gcell(2.0)+four_pt
         masked=water
         fill_missing=0.
-        rel_path=default:urbfrac_gaia2020_30s/
+        rel_path=default:impfrac_gaia2020_30s/
         flag_in_output=FLAG_IMPERV
 ===============================
 name=CANFRA

--- a/geogrid/GEOGRID.TBL.ARW.noahmp
+++ b/geogrid/GEOGRID.TBL.ARW.noahmp
@@ -428,6 +428,16 @@ name=URB_PARAM
         rel_path=default:NUDAPT44_1km/
         flag_in_output=FLAG_URB_PARAM
 ===============================
+name=URB_PARAM
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        z_dim_name=num_urb_params
+        interp_option=default: average_gcell(2.0)+nearest_neighbor
+        rel_path=default:gloucp2020_30s/
+        flag_in_output=FLAG_URB_PARAM
+===============================
 name=FRC_URB2D
         priority=1
         optional=yes
@@ -435,6 +445,15 @@ name=FRC_URB2D
         fill_missing = 0.
         interp_option=default: average_gcell(2.0)+four_pt
         rel_path=default:urbfrac_nlcd2011/
+        flag_in_output=FLAG_FRC_URB2D
+===============================
+name=FRC_URB2D
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        interp_option=default: average_gcell(2.0)+four_pt
+        rel_path=default:urbfrac_gaia2020_30s/
         flag_in_output=FLAG_FRC_URB2D
 ===============================
 name=IMPERV
@@ -445,6 +464,16 @@ name=IMPERV
         masked=water
         fill_missing=0.
         rel_path = default:nlcd2011_imp_ll_9s/
+        flag_in_output=FLAG_IMPERV
+===============================
+name=IMPERV
+        priority=2
+        optional=yes
+        dest_type=continuous
+        interp_option = default:average_gcell(2.0)+four_pt
+        masked=water
+        fill_missing=0.
+        rel_path=default:impfrac_gaia2020_30s/
         flag_in_output=FLAG_IMPERV
 ===============================
 name=CANFRA

--- a/geogrid/GEOGRID.TBL.ARW_CHEM
+++ b/geogrid/GEOGRID.TBL.ARW_CHEM
@@ -428,6 +428,16 @@ name=URB_PARAM
         rel_path=default:NUDAPT44_1km/
         flag_in_output=FLAG_URB_PARAM
 ===============================
+name=URB_PARAM
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        z_dim_name=num_urb_params
+        interp_option=default: average_gcell(2.0)+nearest_neighbor
+        rel_path=default:gloucp2020_30s/
+        flag_in_output=FLAG_URB_PARAM
+===============================
 name=FRC_URB2D
         priority=1
         optional=yes
@@ -435,6 +445,15 @@ name=FRC_URB2D
         fill_missing = 0.
         interp_option=default: average_gcell(2.0)+four_pt
         rel_path=default:urbfrac_nlcd2011/
+        flag_in_output=FLAG_FRC_URB2D
+===============================
+name=FRC_URB2D
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        interp_option=default: average_gcell(2.0)+four_pt
+        rel_path=default:urbfrac_gaia2020_30s/
         flag_in_output=FLAG_FRC_URB2D
 ===============================
 name=IMPERV
@@ -445,6 +464,16 @@ name=IMPERV
         masked=water
         fill_missing=0.
         rel_path = default:nlcd2011_imp_ll_9s/
+        flag_in_output=FLAG_IMPERV
+===============================
+name=IMPERV
+        priority=2
+        optional=yes
+        dest_type=continuous
+        interp_option = default:average_gcell(2.0)+four_pt
+        masked=water
+        fill_missing=0.
+        rel_path=default:impfrac_gaia2020_30s/
         flag_in_output=FLAG_IMPERV
 ===============================
 name=CANFRA

--- a/geogrid/GEOGRID.TBL.ARW_LCZ
+++ b/geogrid/GEOGRID.TBL.ARW_LCZ
@@ -435,6 +435,16 @@ name=URB_PARAM
         rel_path=default:NUDAPT44_1km/
         flag_in_output=FLAG_URB_PARAM
 ===============================
+name=URB_PARAM
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        z_dim_name=num_urb_params
+        interp_option=default: average_gcell(2.0)+nearest_neighbor
+        rel_path=default:gloucp2020_30s/
+        flag_in_output=FLAG_URB_PARAM
+===============================
 name=FRC_URB2D
         priority=1
         optional=yes
@@ -442,6 +452,15 @@ name=FRC_URB2D
         fill_missing = 0.
         interp_option=default: average_gcell(2.0)+four_pt
         rel_path=default:urbfrac_nlcd2011/
+        flag_in_output=FLAG_FRC_URB2D
+===============================
+name=FRC_URB2D
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        interp_option=default: average_gcell(2.0)+four_pt
+        rel_path=default:urbfrac_gaia2020_30s/
         flag_in_output=FLAG_FRC_URB2D
 ===============================
 name=IMPERV
@@ -452,6 +471,16 @@ name=IMPERV
         masked=water
         fill_missing=0.
         rel_path = default:nlcd2011_imp_ll_9s/
+        flag_in_output=FLAG_IMPERV
+===============================
+name=IMPERV
+        priority=2
+        optional=yes
+        dest_type=continuous
+        interp_option = default:average_gcell(2.0)+four_pt
+        masked=water
+        fill_missing=0.
+        rel_path=default:impfrac_gaia2020_30s/
         flag_in_output=FLAG_IMPERV
 ===============================
 name=CANFRA

--- a/geogrid/GEOGRID.TBL.FIRE
+++ b/geogrid/GEOGRID.TBL.FIRE
@@ -428,6 +428,16 @@ name=URB_PARAM
         rel_path=default:NUDAPT44_1km/
         flag_in_output=FLAG_URB_PARAM
 ===============================
+name=URB_PARAM
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        z_dim_name=num_urb_params
+        interp_option=default: average_gcell(2.0)+nearest_neighbor
+        rel_path=default:gloucp2020_30s/
+        flag_in_output=FLAG_URB_PARAM
+===============================
 name=FRC_URB2D
         priority=1
         optional=yes
@@ -435,6 +445,15 @@ name=FRC_URB2D
         fill_missing = 0.
         interp_option=default: average_gcell(2.0)+four_pt
         rel_path=default:urbfrac_nlcd2011/
+        flag_in_output=FLAG_FRC_URB2D
+===============================
+name=FRC_URB2D
+        priority=2
+        optional=yes
+        dest_type=continuous
+        fill_missing = 0.
+        interp_option=default: average_gcell(2.0)+four_pt
+        rel_path=default:urbfrac_gaia2020_30s/
         flag_in_output=FLAG_FRC_URB2D
 ===============================
 name=IMPERV
@@ -445,6 +464,16 @@ name=IMPERV
         masked=water
         fill_missing=0.
         rel_path = default:nlcd2011_imp_ll_9s/
+        flag_in_output=FLAG_IMPERV
+===============================
+name=IMPERV
+        priority=2
+        optional=yes
+        dest_type=continuous
+        interp_option = default:average_gcell(2.0)+four_pt
+        masked=water
+        fill_missing=0.
+        rel_path=default:impfrac_gaia2020_30s/
         flag_in_output=FLAG_IMPERV
 ===============================
 name=CANFRA


### PR DESCRIPTION
This PR is to add new WPS dataset for global 1-km urban parameters (URB_PARAM) based on the new GloUCP data for year 2020 conditions (Liao et al 2025) and global 1-km urban/impervious surface fraction (FRC_URB2D and IMPERV) based on the Global Artificial Impervious Area (GAIA) dataset for year 2020 conditions (Gong et al. 2020).

The default URB_PARAM, FRC_URB2D and IMPERV variables are based on the outdated NLCD and NUDAPT urban data for year 2010 and only available over continental US. The new data covers global urban areas and is more updated. Thus, in this PR, I give higher data priority to these new datasets by default.

The WPS-compatible data with index files are available here on Derecho:
For URB_PARAM: /glade/work/wrfhelp/WPS_GEOG/gloucp2020_30s
For FRC_URB2D (0-1, fraction): /glade/work/wrfhelp/WPS_GEOG/urbfrac_gaia2020_30s
For IMPERV (0-100, percent): /glade/work/wrfhelp/WPS_GEOG/impfrac_gaia2020_30s

These datasets should be also be made available on the WRF data website (https://www2.mmm.ucar.edu/wrf/users/download/get_sources_wps_geog.html)

Tests have been done successfully by Cenlin He (NCAR) on Derecho.

Raw datasets are available for downloading: https://figshare.com/articles/dataset/_b_GloUCP_b_A_global_1_km_spatially_continuous_urban_canopy_parameters_for_the_WRF_model_/27011491

References:

- Liao, W., Li, Y., Liu, X., Wang, Y., Che, Y., Shao, L., Chen, G., Yuan, H., Zhang, N., and Chen, F.: GloUCP: a global 1 km spatially continuous urban canopy parameters for the WRF model, Earth Syst. Sci. Data, 17, 2535–2551, https://doi.org/10.5194/essd-17-2535-2025, 2025.
- Gong, P., Li, X.C., Wang, J., Bai, Y., Chen, B., Hu, T.Y., Liu, X.P., Xu, B., Yang, J., Zhang, W., & Zhou, Y.Y. 2020. Annual maps of global artificial impervious areas (GAIA) between 1985 and 2018. Remote Sensing of Environment, 236, 111510. doi: 10.1016/j.rse.2019.111510.



