### PR TITLE
CMake Ensure defines for ungrib reading tools are set for all languages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,8 +161,8 @@ list( TRANSFORM WPS_DEFINITIONS_LIST REPLACE "^-D(.*)" "\\1" )
 add_compile_definitions( 
                         ${WPS_DEFINITIONS_LIST}
                         ${WPS_UNDEFINITIONS_LIST}
-                        $<$<COMPILE_LANGUAGE:Fortran>:USE_JPEG2000>
-                        $<$<COMPILE_LANGUAGE:Fortran>:USE_PNG>
+                        USE_JPEG2000
+                        USE_PNG
                         )
 # Whole project flags
 add_compile_options(


### PR DESCRIPTION
When building WPS with CMake, certain compile definitions ( `USE_JPEG2000` and `USE_PNG`) were only being set for Fortran files. This caused issues when compiling C files that also needed these definitions.

The fix involves adding these definitions globally, ensuring they are available for all source files regardless of language. The files that are specifically affected during compilation with these changes are under the ungrib/src/ngl/g2 directory:
* dec_jpeg2000.c / enc_jpeg2000.c
* dec_png.c / enc_png.c

This change does not impact the make build process, and only affects CMake builds.

Addresses issue #279 