### PR TITLE
update ungrib to handle files larger than 2GB

### DIFF
--- a/ungrib/src/g2print.F
+++ b/ungrib/src/g2print.F
@@ -161,8 +161,8 @@ end program g2print
       character(len=8)  :: pabbrev
       character(len=20) :: labbrev
       character(len=80) :: tabbrev
-      integer :: lskip, lgrib
-      integer :: junit, itot, icount, iseek
+      integer(kind=8) :: lskip, iseek
+      integer :: lgrib, junit, itot, icount
       integer :: grib_edition
       integer :: i, j, ireaderr, ith
       integer :: currlen
@@ -1010,7 +1010,8 @@ end program g2print
       integer :: listsec0(3)
       integer :: listsec1(13)
       character(len=*)  :: gribflnm
-      integer :: lskip, lgrib
+      integer(kind=8) :: lskip, iseek
+      integer :: lgrib
       integer :: junit
       integer :: grib_edition
       integer :: i, j, ireaderr

--- a/ungrib/src/ngl/g2/skgb.f
+++ b/ungrib/src/ngl/g2/skgb.f
@@ -39,6 +39,7 @@ C$$$
       PARAMETER(LSEEK=512)
       CHARACTER Z(LSEEK)
       CHARACTER Z4(4)
+      INTEGER(KIND=8) :: ISEEK, LSKIP, KS, KS2
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       LGRIB=0
       KS=ISEEK
@@ -59,7 +60,8 @@ C  LOOK FOR 'GRIB...1' IN PARTIAL SECTION
 C  LOOK FOR '7777' AT END OF GRIB MESSAGE
             IF (I1.EQ.1) CALL GBYTE(Z,KG,(K+4)*8,3*8)
             IF (I1.EQ.2) CALL GBYTE(Z,KG,(K+12)*8,4*8)
-            CALL BAREAD(LUGB,KS+K+KG-4,4,K4,Z4)
+            KS2=KS+K+KG-4
+            CALL BAREAD(LUGB,KS2,4,K4,Z4)
             IF(K4.EQ.4) THEN
               CALL GBYTE(Z4,I4,0,4*8)
               IF(I4.EQ.926365495) THEN

--- a/ungrib/src/ngl/w3/bacio.v1.3.c
+++ b/ungrib/src/ngl/w3/bacio.v1.3.c
@@ -6,6 +6,10 @@
 /*        Return code for fewer data read/written than requested */
 /*  v1.2: Add cray compatibility  20 April 1998                  */
 
+#ifndef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 64
+#endif
+
 #include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -85,21 +89,22 @@
 /*   to system. */
 #if defined _UNDERSCORE
   int ba_cio_
-         (int * mode, int * start, int *newpos, int * size, int * no, 
+         (int * mode, long long * start, long long *newpos, int * size, int * no,
           int * nactual, int * fdes, const char *fname, char *datary, 
           int  namelen, int  datanamelen) {
 #elif defined _DOUBLEUNDERSCORE
   int ba_cio__
-         (int * mode, int * start, int *newpos, int * size, int * no, 
+         (int * mode, long long * start, long long *newpos, int * size, int * no,
           int * nactual, int * fdes, const char *fname, char *datary, 
           int  namelen, int  datanamelen) {
 #else
   int ba_cio
-         (int * mode, int * start, int *newpos, int * size, int * no, 
+         (int * mode, long long * start, long long *newpos, int * size, int * no,
           int * nactual, int * fdes, const char *fname, char *datary, 
           int  namelen, int  datanamelen) {
 #endif
-  int i, j, jret, seekret;
+  int i, j, jret;
+  off_t seekret;
   char *realname, *tempchar;
   int tcharval;
   size_t count;
@@ -224,16 +229,16 @@
   else if (BAREAD & *mode ) {
   /* Read in some data */
     if (! (*mode & NOSEEK) ) {
-      seekret = lseek(*fdes, *start, SEEK_SET);
+      seekret = lseek(*fdes, (off_t)*start, SEEK_SET);
       if (seekret == -1) {
         #ifdef VERBOSE
-          printf("error in seeking to %d\n",*start);
+          printf("error in seeking to %lld\n",(long long)*start);
         #endif
         return -6;
       }
       #ifdef VERBOSE
       else {
-         printf("Seek successful, seek ret %d, start %d\n", seekret, *start);
+         printf("Seek successful, seek ret %lld, start %lld\n", (long long)seekret, (long long)*start);
       }
       #endif
     }
@@ -261,7 +266,7 @@
     #endif
     }
     *nactual = jret;
-    *newpos = *start + jret;
+    *newpos = *start + (long long)jret;
   }
 /* Done with reading */
  
@@ -274,10 +279,10 @@
   }
   else if ( BAWRITE & *mode ) {
     if (! (*mode & NOSEEK) ) {
-      seekret = lseek(*fdes, *start, SEEK_SET);
+      seekret = lseek(*fdes, (off_t)*start, SEEK_SET);
       if (seekret == -1) {
       #ifdef VERBOSE
-        printf("error in seeking to %d\n",*start);
+        printf("error in seeking to %lld\n",(long long)*start);
       #endif
         return -8;
       }
@@ -300,14 +305,14 @@
       printf("wrote %d bytes instead\n", jret);
     #endif
       *nactual = jret;
-      *newpos = *start + jret;
+      *newpos = *start + (long long)jret;
     }
     else {
     #ifdef VERBOSE
        printf("wrote %d bytes \n", jret);
     #endif
        *nactual = jret;
-       *newpos = *start + jret;
+       *newpos = *start + (long long)jret;
     }
   }
 /* Done with writing */
@@ -337,21 +342,22 @@
 } 
 #if defined _UNDERSCORE
   int banio_
-         (int * mode, int * start, int *newpos, int * size, int * no, 
+         (int * mode, long long * start, long long *newpos, int * size, int * no,
           int * nactual, int * fdes, const char *fname, char *datary, 
           int  namelen ) {
 #elif defined _DOUBLEUNDERSCORE
   int banio__
-         (int * mode, int * start, int *newpos, int * size, int * no, 
+         (int * mode, long long * start, long long *newpos, int * size, int * no,
           int * nactual, int * fdes, const char *fname, char *datary, 
           int  namelen ) {
 #else
   int banio
-         (int * mode, int * start, int *newpos, int * size, int * no, 
+         (int * mode, long long * start, long long *newpos, int * size, int * no,
           int * nactual, int * fdes, const char *fname, char *datary, 
           int  namelen ) {
 #endif
-  int i, j, jret, seekret;
+  int i, j, jret;
+  off_t seekret;
   char *realname, *tempchar;
   int tcharval;
 
@@ -475,16 +481,16 @@
   else if (BAREAD & *mode ) {
   /* Read in some data */
     if (! (*mode & NOSEEK) ) {
-      seekret = lseek(*fdes, *start, SEEK_SET);
+      seekret = lseek(*fdes, (off_t)*start, SEEK_SET);
       if (seekret == -1) {
         #ifdef VERBOSE
-          printf("error in seeking to %d\n",*start);
+          printf("error in seeking to %lld\n",(long long)*start);
         #endif
         return -6;
       }
       #ifdef VERBOSE
       else {
-         printf("Seek successful, seek ret %d, start %d\n", seekret, *start);
+         printf("Seek successful, seek ret %lld, start %lld\n", (long long)seekret, (long long)*start);
       }
       #endif
     }
@@ -495,13 +501,13 @@
         printf("read in %d items of %d \n",jret/(*size), *no);
       #endif
       *nactual = jret/(*size);
-      *newpos = *start + jret;
+      *newpos = *start + (long long)jret;
     }  
     #ifdef VERBOSE
       printf("read in %d items \n", jret/(*size));
     #endif
     *nactual = jret/(*size);
-    *newpos = *start + jret;
+    *newpos = *start + (long long)jret;
   }
 /* Done with reading */
  
@@ -514,16 +520,16 @@
   }
   else if ( BAWRITE & *mode ) {
     if (! (*mode & NOSEEK) ) {
-      seekret = lseek(*fdes, *start, SEEK_SET);
+      seekret = lseek(*fdes, (off_t)*start, SEEK_SET);
       if (seekret == -1) {
       #ifdef VERBOSE
-        printf("error in seeking to %d\n",*start);
+        printf("error in seeking to %lld\n",(long long)*start);
       #endif
         return -8;
       }
       #ifdef VERBOSE
       else {
-        printf("Seek successful, seek ret %d, start %d\n", seekret, *start);
+        printf("Seek successful, seek ret %lld, start %lld\n", (long long)seekret, (long long)*start);
       }
       #endif
     }
@@ -534,14 +540,14 @@
       printf("wrote %d items instead\n", jret/(*size) );
     #endif
       *nactual = jret/(*size) ;
-      *newpos = *start + jret;
+      *newpos = *start + (long long)jret;
     }
     else {
     #ifdef VERBOSE
        printf("wrote %d items \n", jret/(*size) );
     #endif
        *nactual = jret/(*size) ;
-       *newpos = *start + jret;
+       *newpos = *start + (long long)jret;
     }
   }
 /* Done with writing */

--- a/ungrib/src/ngl/w3/baciof.f
+++ b/ungrib/src/ngl/w3/baciof.f
@@ -89,6 +89,7 @@ C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
       CHARACTER(80) CMSG
+      INTEGER(KIND=8) :: IB, JB
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -130,6 +131,7 @@ C
 C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
+      INTEGER(KIND=8) :: IB, JB
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -171,6 +173,7 @@ C
 C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
+      INTEGER(KIND=8) :: IB, JB
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -212,6 +215,7 @@ C
 C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
+      INTEGER(KIND=8) :: IB, JB
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -253,6 +257,7 @@ C
 C$$$
       USE BACIO_MODULE
       CHARACTER CFN*(*)
+      INTEGER(KIND=8) :: IB, JB
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -293,6 +298,7 @@ C   LANGUAGE: FORTRAN 90
 C
 C$$$
       USE BACIO_MODULE
+      INTEGER(KIND=8) :: IB, JB
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(LU.LT.001.OR.LU.GT.999) THEN
         IRET=6
@@ -342,10 +348,13 @@ C   LANGUAGE: FORTRAN 90
 C
 C$$$
       USE BACIO_MODULE
+      INTEGER(KIND=8) :: IB
+      INTEGER(KIND=8) :: JB, IB0
       CHARACTER A(NB)
       CHARACTER CFN
       PARAMETER(NY=4096,MY=4)
-      INTEGER NS(MY),NN(MY)
+      INTEGER(KIND=8) :: NS(MY)
+      INTEGER NN(MY)
       CHARACTER Y(NY,MY)
       DATA LUX/0/
       SAVE JY,NS,NN,Y,LUX
@@ -362,13 +371,15 @@ C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         KA=0
         RETURN
       ENDIF
+      IB0=0
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 C  UNBUFFERED I/O
       IF(BAOPTS(1).NE.1) THEN
         IF(IB.GE.0) THEN
           IRET=BA_CIO(BACIO_READ,IB,JB,1,NB,KA,FD(LU),CFN,A)
         ELSE
-          IRET=BA_CIO(BACIO_READ+BACIO_NOSEEK,0,JB,1,NB,KA,FD(LU),CFN,A)
+          IRET=BA_CIO(BACIO_READ+BACIO_NOSEEK,IB0,JB,1,NB,KA,
+     &               FD(LU),CFN,A)
         ENDIF
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 C  BUFFERED I/O
@@ -456,6 +467,8 @@ C   LANGUAGE: FORTRAN 90
 C
 C$$$
       USE BACIO_MODULE
+      INTEGER(KIND=8) :: IB
+      INTEGER(KIND=8) :: JB, IB0
       CHARACTER A(NB)
       CHARACTER CFN
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -467,11 +480,13 @@ C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
         KA=0
         RETURN
       ENDIF
+      IB0=0
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(IB.GE.0) THEN
         IRET=BA_CIO(BACIO_WRITE,IB,JB,1,NB,KA,FD(LU),CFN,A)
       ELSE
-        IRET=BA_CIO(BACIO_WRITE+BACIO_NOSEEK,0,JB,1,NB,KA,FD(LU),CFN,A)
+        IRET=BA_CIO(BACIO_WRITE+BACIO_NOSEEK,IB0,JB,1,NB,KA,
+     &              FD(LU),CFN,A)
       ENDIF
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       END
@@ -508,6 +523,7 @@ C   LANGUAGE: FORTRAN 90
 C
 C$$$
       USE BACIO_MODULE
+      INTEGER(KIND=8) :: JB, IB0
       CHARACTER A(NB)
       CHARACTER CFN
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -517,8 +533,9 @@ C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       IF(NB.LE.0) THEN
         RETURN
       ENDIF
+      IB0=0
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-      IRET=BA_CIO(BACIO_WRITE+BACIO_NOSEEK,0,JB,1,NB,KA,FD(LU),CFN,A)
+      IRET=BA_CIO(BACIO_WRITE+BACIO_NOSEEK,IB0,JB,1,NB,KA,FD(LU),CFN,A)
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       RETURN
       END

--- a/ungrib/src/rd_grib2.F
+++ b/ungrib/src/rd_grib2.F
@@ -56,8 +56,8 @@
       character(len=8)  :: pabbrev
       character(len=20) :: labbrev
       character(len=80) :: tabbrev
-      integer :: lskip, lgrib
-      integer :: junit, itot, icount, iseek
+      integer(kind=8) :: lskip, iseek
+      integer :: lgrib, junit, itot, icount
       integer :: grib_edition
       integer :: i, j, ireaderr, ith , debug_level
       integer :: currlen
@@ -943,7 +943,8 @@ C  SET ARGUMENTS
       integer :: listsec0(3)
       integer :: listsec1(13)
       character(len=*)  :: gribflnm
-      integer :: lskip, lgrib
+      integer(kind=8) :: lskip, iseek
+      integer :: lgrib
       integer :: junit
       integer :: grib_edition
       integer :: i, j, ireaderr


### PR DESCRIPTION
1. Update byte offset variables (start/newpos in C, IB/JB in Fortran, iseek/lskip/KS in callers) to use 64-bit
2. Byte count variables (NB/lgrib/no/size/nactual) remain 32-bit, assuming individual GRIB messages are under 2GB
3. Use `long long` C type to match Fortran's `INTEGER(KIND=8)`