### PR TITLE
CMake: Fix parallel-build race on shared ungrib Fortran modules

### DIFF
--- a/ungrib/src/CMakeLists.txt
+++ b/ungrib/src/CMakeLists.txt
@@ -25,18 +25,16 @@ target_sources(
                   cio.c
                   module_debug.F
                   misc_definitions_module.F
+                  debug_cio.c
+                  module_datarray.F
+                  gridinfo.F
+                  filelist.F
                 )
 
 target_sources(
                 ungrib
                 PRIVATE
-                  debug_cio.c
-                  module_stringutil.F
-                  table.F
-                  module_datarray.F
-                  gridinfo.F
                   new_storage.F
-                  filelist.F
                   ungrib.F
                   output.F
                   rrpr.F
@@ -50,15 +48,10 @@ target_sources(
                 g1print
                 PRIVATE
                   g1print.F
-                  gribcode.F
-                  module_debug.F
-                  debug_cio.c
                 )
 
 target_sources(
                 g2print
                 PRIVATE
-                  filelist.F
-                  gridinfo.F
                   g2print.F
                 )


### PR DESCRIPTION
TYPE: bug fix

KEYWORDS: cmake, ungrib, parallel build, fortran module, race condition

SOURCE: internal

DESCRIPTION OF CHANGES:
Problem:
In the CMake build, the ungrib, g1print, and g2print targets each
recompiled shared sources (gridinfo.F, filelist.F, table.F,
module_stringutil.F, gribcode.F, module_debug.F, debug_cio.c,
module_datarray.F) into a single shared Fortran_MODULE_DIRECTORY. Under
a parallel build (-j), two targets could compile the same source at the
same time and both write the same .mod, causing an intermittent fatal
error, e.g.:

  f951: Fatal Error: Cannot rename module file '.../gridinfo.mod0' to
  '.../gridinfo.mod': No such file or directory

Because it is a timing-dependent race, the build failed only on some
runs.

Solution:
Compile each shared source exactly once into the pgu library and have
ungrib, g1print, and g2print link pgu instead of recompiling those
sources. This mirrors the traditional Makefile build, where shared
objects are built once and linked into each executable. The existing
link dependencies on pgu also guarantee the shared modules are built
before the executables, removing the race without disabling parallelism.

TESTS CONDUCTED:
Clean parallel build (-j) of WPS repeated multiple times; ungrib,
g1print, and g2print build and link successfully with no module-rename
errors.

RELEASE NOTE: Fix intermittent parallel-build failure caused by
concurrent writes to shared ungrib Fortran module files.