### PR TITLE
Fix use of uninitialized is_subgrid_var variable in init_output_fields routine

### DIFF
--- a/geogrid/src/output_module.F
+++ b/geogrid/src/output_module.F
@@ -469,6 +469,7 @@ module output_module
       ifieldstatus = 0
       nfields = 0
       optstatus = 0
+      is_subgrid_var = .false.
       do while (ifieldstatus == 0)
    
          call get_next_output_fieldname(nest_num, fieldname, ndims, &


### PR DESCRIPTION
This PR fixes the use of an uninitialized variable, `is_subgrid_var`, in the `init_output_fields` routine.

In the `init_output_fields` routine, the `is_subgrid_var` local variable was previously being used before it was initialized (and in fact, that variable was never set anywhere in the routine). The ultimate effect of the use of the uninitialized `is_subgrid_var` variable was a lack of output variables being defined in metgrid output files, though this effect was observable only under certain conditions (e.g., with GNU compiler versions >= 14.2.0, for example).