### PR TITLE
Address floating-point comparison issue for glevel1 and glevel2 in rd_grib2

### DIFF
--- a/ungrib/src/rd_grib2.F
+++ b/ungrib/src/rd_grib2.F
@@ -736,8 +736,8 @@ C  SET ARGUMENTS
                 TMP8LOOP: do j = 1, maxvar
                   if ((g2code(4,j) .eq. 106) .and.
      &               (gfld%ipdtmpl(2) .eq. g2code(3,j)) .and.
-     &               (glevel1 .eq. level1(j)) .and.
-     &               ((glevel2 .eq. level2(j)) .or.
+     &               (nint(glevel1) .eq. level1(j)) .and.
+     &               ((nint(glevel2) .eq. level2(j)) .or.
      &                                   (level2(j) .le. -88))) then
                     my_field = namvar(j)
                     exit TMP8LOOP


### PR DESCRIPTION
This PR addresses a floating-point comparison issue for the variables `glevel1` and `glevel2` in the `rd_grib2` subroutine.

In the `rd_grib2` routine, soil levels in centimeters are computed as real values (`glevel1` and `glevel2`) from level information in GRIB files, and these are later compared with integer levels requested in the `Vtable`. Under certain compilation environments, the computed soil levels will not compare exactly with the requested integer levels, leading to the omission of soil fields from the intermediate output files.

This PR addresses the floating-point comparison issue by rounding `glevel1` and `glevel2` to the nearest integer using the Fortran `nint` intrinsic before comparing with the requested integer levels from the `Vtable`.